### PR TITLE
Added Hoon standard library functions.

### DIFF
--- a/lib/hoon-dictionary.json
+++ b/lib/hoon-dictionary.json
@@ -680,5 +680,3319 @@
       "!!"
     ],
     "doc": "<h1><code>:fail  !!  \"zapzap\"</code></h1>\n<p><code>{$fail $~}</code>: crash.</p>\n<h2>Produces</h2>\n<p>Nothing.  Always crashes, with span <code>%void</code>.</p>\n<h2>Syntax</h2>\n<p><code>!!</code></p>\n<h2>Discussion</h2>\n<p><code>%void</code> nests in every other span, so you can stub out anything with <code>!!</code>.</p>\n<h2>Examples</h2>\n<p><code>~zod:dojo&gt; !!\n! exit</code></p>"
+  },
+
+  {
+    "keys": [
+      "add"
+    ],
+    "doc": "<h1><code>++add</code></h1>\n\n<p>Add</p>\n\n<p>Produces the sum of <code>a</code> and <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  add                                                 ::  add\n  ~/  %add\n  |=  [a/@ b/@]\n  ^-  @\n  ?:  =(0 a)  b\n  $(a (dec a), b +(b))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (add 2 2)\n4\n&gt; (add 1 1.000.000)\n1.000.001\n&gt; (add 1.333 (mul 2 2))\n1.337\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dec"
+    ],
+    "doc": "<h1><code>++dec</code></h1>\n\n<p>Decrement</p>\n\n<p>Decrements <code>a</code> by <code>1</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  dec                                                 ::  decrement\n  ~/  %dec\n  |=  a/@\n  ~|  %decrement-underflow\n  ?&lt;  =(0 a)\n  =+  b=0\n  |-  ^-  @\n  ?:  =(a +(b))  b\n  $(b +(b))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (dec 7)\n6\n&gt; (dec 0)\n! decrement-underflow\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "div"
+    ],
+    "doc": "<h1><code>++div</code></h1>\n\n<p>Divide</p>\n\n<p>Computes <code>a</code> divided by <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  div                                                 ::  divide\n  ~/  %div\n  |=  [a/@ b/@]\n  ^-  @\n  ~|  'div'\n  ?&lt;  =(0 b)\n  =+  c=0\n  |-\n  ?:  (lth a b)  c\n  $(a (sub a b), c +(c))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (div 4 2)\n2\n&gt; (div 17 8)\n2\n&gt; (div 20 30)\n0\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gte"
+    ],
+    "doc": "<h1><code>++gte</code></h1>\n\n<p>Greater-than/equal</p>\n\n<p>Tests whether <code>a</code> is greater than a number <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gte                                                 ::  greater-equal\n  ~/  %gte\n  |=  {a/@ b/@}\n  ^-  ?\n  !(lth a b)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (gte 100 10)\n%.y\n&gt; (gte 4 4)\n%.y\n&gt; (gte 3 4)\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gth"
+    ],
+    "doc": "<h1><code>++gth</code></h1>\n\n<p>Greater-than</p>\n\n<p>Tests whether <code>a</code> is greater than <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gth                                                 ::  greater-than\n  ~/  %gth\n  |=  {a/@ b/@}\n  ^-  ?\n  !(lte a b)\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (gth 'd' 'c')\n%.y\n&gt; (gth ~h1 ~m61)\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "lte"
+    ],
+    "doc": "<h1><code>++lte</code></h1>\n\n<p>Less-than/equal</p>\n\n<p>Tests whether <code>a</code> is less than or equal to <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  lte                                                 ::  less-equal\n  ~/  %lte\n  |=  {a/@ b/@}\n  |(=(a b) (lth a b))\n\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (lte 4 5)\n%.y\n&gt; (lte 5 4)\n%.n\n&gt; (lte 5 5)\n%.y\n&gt; (lte 0 0)\n%.y\n</code></pre>"
+  },
+  {
+    "keys": [
+      "lth"
+    ],
+    "doc": "<h1><code>++lth</code></h1>\n\n<p>Less-than</p>\n\n<p>Tests whether <code>a</code> is less than <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  lth                                                 ::  less-than\n  ~/  %lth\n  |=  {a/@ b/@}\n  ^-  ?\n  ?&amp;  !=(a b)\n      |-\n      ?|  =(0 a)\n          ?&amp;  !=(0 b)\n              $(a (dec a), b (dec b))\n  ==  ==  ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (lth 4 5)\n%.y\n&gt; (lth 5 4)\n%.n\n&gt; (lth 5 5)\n%.n\n&gt; (lth 5 0)\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "max"
+    ],
+    "doc": "<h1><code>++max</code></h1>\n\n<p>Maximum</p>\n\n<p>Computes the greater of <code>a</code> and <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  max                                                 ::  maximum\n  ~/  %max\n  |=  {a/@ b/@}\n  ^-  @\n  ?:  (gth a b)  a\n  b\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (max 10 100)\n100\n&gt; (max 10.443 9)\n10.443\n&gt; (max 0 1)\n1\n</code></pre>"
+  },
+  {
+    "keys": [
+      "min"
+    ],
+    "doc": "<h1><code>++min</code></h1>\n\n<p>Minimum</p>\n\n<p>Computes the lesser of <code>a</code> and <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  min                                                 ::  minimum\n  ~/  %min\n  |=  {a/@ b/@}\n  ^-  @\n  ?:  (lth a b)  a\n  b\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (min 10 100)\n10\n&gt; (min 10.443 9)\n9\n&gt; (min 0 1)\n0\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mod"
+    ],
+    "doc": "<h1><code>++mod</code></h1>\n\n<p>Modulus</p>\n\n<p>Computes the remainder of dividing <code>a</code> by <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mod                                                 ::  remainder\n  ~/  %mod\n  |:  [a=`@`1 b=`@`1]\n  ^-  @\n  ?&lt;  =(0 b)\n  (sub a (mul b (div a b)))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mod 5 2)\n1\n&gt; (mod 5 5)\n0\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mul"
+    ],
+    "doc": "<h1><code>++mul</code></h1>\n\n<p>Multiply</p>\n\n<p>Multiplies <code>a</code> by <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mul                                                 ::  multiply\n  ~/  %mul\n  |:  [a=`@`1 b=`@`1]\n  ^-  @\n  =+  c=0\n  |-\n  ?:  =(0 a)  c\n  $(a (dec a), c (add b c))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mul 3 4)\n 12 \n&gt; (mul 0 1) \n0\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "cap"
+    ],
+    "doc": "<h1><code>++cap</code></h1>\n\n<p>Tree head</p>\n\n<p>Tests whether an <code>a</code> is in the head or tail of a noun. Produces the\ncube <code>%2</code> if it is within the head, or the cube <code>%3</code> if it is\nwithin the tail.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A cube.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  cap                                                 ::  tree head\n      ~/  %cap\n      |=  a=@\n      ^-  ?(%2 %3)\n      ?-  a\n        %2        %2\n        %3        %3\n        ?(%0 %1)  !!\n        *         $(a (div a 2))\n      ==\n    ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (cap 4)\n%2\n&gt; (cap 6)\n%3\n&gt; (cap (add 10 9))\n%2\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mas"
+    ],
+    "doc": "<h1><code>++mas</code></h1>\n\n<p>Axis within head/tail?</p>\n\n<p>Computes the axis of <code>a</code> within either the head or tail of a noun (depends whether <code>a</code> lies within the the head or tail).</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an <a href=\"\">atom</a>.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  mas                                                 ::  tree body\n      ~/  %mas\n      |=  a=@\n      ^-  @\n      ?-  a\n        1   !!\n        2   1\n        3   1\n        *   (add (mod a 2) (mul $(a (div a 2)) 2))\n      ==\n    ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mas 3)\n1\n&gt; (mas 4)\n2\n&gt; (mas 5)\n3\n&gt; (mas 6)\n2\n&gt; (mas 0)\n! exit\n&gt; (mas 1)\n! exit\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "bloq"
+    ],
+    "doc": "<h1><code>++bloq</code></h1>\n\n<p>Blocksize</p>\n\n<p>Atom representing a blocksize, by convention expressed as a power of 2.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bloq  @                                            ::  blockclass\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; :: ++met measures how many bloqs long an atom is\n&gt; (met 3 256)\n2\n&gt; :: 256 is 2 bloqs of 2^3\n</code></pre>"
+  },
+  {
+    "keys": [
+      "each"
+    ],
+    "doc": "<h1><code>++each</code></h1>\n\n<p>Mold of fork between two</p>\n\n<p>mold generator: produces a dicriminated fork between two types.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  each\n      |*  {a/$-(* *) b/$-(* *)}                     ::  either a or b\n      $%({$&amp; p/a} {$| p/b})                         ::    a default\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ? *(each cord time)\n  ?({$.y p/@t} {$.n p/@da})\n[%.y p='']\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gate"
+    ],
+    "doc": "<h1><code>++gate</code></h1>\n\n<p>Function</p>\n\n<p>A core with one arm, <code>$</code>--the empty name--which transforms a sample noun into a product\nnoun. If used dryly as a type, the subject must have a sample type of <code>*</code>.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  gate  $-(* *)                                       ::  general gate\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>See also: <code>++lift</code>, <code>++cork</code></p>\n\n<pre><code>&gt; ? gate\n  &lt;1.ybc {* &lt;110.jyx 1.ztu $151&gt;}&gt;\n&lt;1.ybc {* &lt;110.jyx 1.ztu $151&gt;}&gt;\n\n&gt; (`gate`|=(a/* [a 'b']) 1)\n[1 'b']\n</code></pre>"
+  },
+  {
+    "keys": [
+      "list"
+    ],
+    "doc": "<h1><code>++list</code></h1>\n\n<p>List</p>\n\n<p>mold generator. <code>++list</code> generates a mold of a null-termanated list of a\nhomogenous type.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  list  |*  a/$-(* *)                                 ::  null-term list\n          $@($~ {i/a t/(list a)})                       ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>See also: <code>++turn</code>, <code>++snag</code></p>\n\n<pre><code>&gt; *(list)\n~\n&gt; `(list @)`\"abc\"\n~[97 98 99]\n&gt; (snag 0 \"abc\")\n'a'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "lone"
+    ],
+    "doc": "<h1><code>++lone</code></h1>\n\n<p><code>++lone</code> puts face of <code>p</code> on something.</p>\n\n<p>XX unused</p>\n\n<h2>Source</h2>\n\n<pre><code>++  lone  |*(a/$-(* *) p/a)                             ::  just one thing\n</code></pre>"
+  },
+  {
+    "keys": [
+      "pair"
+    ],
+    "doc": "<h1><code>++pair</code></h1>\n\n<p>Mold of pair of types</p>\n\n<p>mold generator. Produces a tuple of two of the types passed in.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  pair  |*({a/$-(* *) b/$-(* *)} {p/a q/b})           ::  just a pair\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *(pair bean cord)\n[p=%.y q='']\n</code></pre>"
+  },
+  {
+    "keys": [
+      "pole"
+    ],
+    "doc": "<h1><code>++pole</code></h1>\n\n<p>Faceless list</p>\n\n<p>A <code>++list</code> without the faces <code>i</code> and <code>t</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  pole  |*  a/$-(* *)                                 ::  nameless list\n          $@($~ {a (pole a)})                           ::\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `(pole char)`\"asdf\"\n[~~a [~~s [~~d [~~f ~]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "qual"
+    ],
+    "doc": "<h1><code>++qual</code></h1>\n\n<p>Mold of 4 type tuple</p>\n\n<p>A <code>++qual</code> is a tuple of four of the types passed in.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  qual  |*  {a/$-(* *) b/$-(* *) c/$-(* *) d/$-(* *)} ::  just a quadruple\n          {p/a q/b r/c s/d}                             ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *(qual date time tape cord)\n[p=[[a=%.y y=0] m=0 t=[d=0 h=0 m=0 s=0 f=~]] q=~292277024401-.1.1 r=\"\" s='']\n</code></pre>\n\n\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "trap"
+    ],
+    "doc": "<h1><code>++trap</code></h1>\n\n<p>Core with one arm <code>$</code></p>\n\n<p>A trap is a core with one arm <code>++$</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  trap  |*(a/_* _|?(*a))                        ::  makes perfect sense\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *trap\n&lt;1.mws 101.jzo 1.ypj %164&gt;\n&gt; (*trap)\n0\n&gt; (|.(42))\n42\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tree"
+    ],
+    "doc": "<h1><code>++tree</code></h1>\n\n<p>Tree mold generator</p>\n\n<p>A <code>++tree</code> can be empty, or contain a node of a type and\nleft/right sub <code>++tree</code> of the same type. Pretty-printed with <code>{}</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  tree  |*  a/$-(* *)                                 ::  binary tree\n          $@($~ {n/a l/(tree a) r/(tree a)})            ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `(tree {@ tape})`[[1 \"hi\"] [[2 \"bye\"] ~ ~] ~]\n{[2 \"bye\"] [1 \"hi\"]}\n</code></pre>"
+  },
+  {
+    "keys": [
+      "trel"
+    ],
+    "doc": "<h1><code>++trel</code></h1>\n\n<p>Mold of three types</p>\n\n<p><code>++mold</code> of the tuple of the three types passed in.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  trel  |*  {a/$-(* *) b/$-(* *) c/$-(* *)}           ::  just a triple\n          {p/a q/b r/c}                                 ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *(trel @ud @t @s)\n[p=0 q='' r=--0]\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "biff"
+    ],
+    "doc": "<h1><code>++biff</code></h1>\n\n<p>Unit as argument</p>\n\n<p>Applies a function <code>b</code> that produces a unit to the unwrapped value of ++unit\n<code>a</code> (<code>u.a</code>). If <code>a</code> is empty, <code>~</code> is produced.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a unit.</p>\n\n<p><code>b</code> is a function that accepts a noun and produces a unit.</p>\n\n<h2>Produces</h2>\n\n<p>A unit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  biff                                                ::  apply\n  |*  {a/(unit) b/$-(* (unit))}\n  ?~  a  ~\n  (b u.a)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (biff (some 5) |=(a/@ (some (add a 2))))\n[~ u=7]\n&gt; (biff ~ |=(a/@ (some (add a 2))))\n~\n</code></pre>"
+  },
+  {
+    "keys": [
+      "bind"
+    ],
+    "doc": "<h1><code>++bind</code></h1>\n\n<p>Non-unit function to unit, producing unit</p>\n\n<p>Applies a function <code>b</code> to the value (<code>u.a</code>) of a ++unit <code>a</code>, producing\na unit. Used when you want a function that does not accept or produce a\nunit to both accept and produce a unit.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a unit.</p>\n\n<p><code>b</code> is a function.</p>\n\n<h2>Produces</h2>\n\n<p>A unit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bind                                                ::  argue\n  |*  {a/(unit) b/gate}\n  ?~  a  ~\n  [~ u=(b u.a)]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (bind ((unit @) [~ 97]) ,@t)\n[~ `a`]\n&gt; =a |=(a/@ (add a 1))\n&gt; (bind ((unit @) [~ 2]) a)\n[~ 3]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "bond"
+    ],
+    "doc": "<h1><code>++bond</code></h1>\n\n<p>Replace null</p>\n\n<p>Replaces an empty ++unit <code>b</code> with the product of a called trap\n<code>a</code>. If the unit is not empty, then the original unit is produced.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a trap.</p>\n\n<p><code>b</code> is a unit.</p>\n\n<h2>Produces</h2>\n\n<p>Either the product of <code>a</code> or the value inside of unit <code>b</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bond                                                ::  replace\n  |*  a/(trap)\n  |*  b/(unit)\n  ?~  b  $:a\n  u.b\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (bex 10)\n1.024\n&gt; ((bond |.((bex 10))) ~)\n1.024\n&gt; ((bond |.((bex 10))) (slaw %ud '123'))\n123\n</code></pre>"
+  },
+  {
+    "keys": [
+      "both"
+    ],
+    "doc": "<h1><code>++both</code></h1>\n\n<p>Group unit values into pair</p>\n\n<p>Produces <code>~</code> if either <code>a</code> or <code>b</code> are empty. Otherwise, produces a\n++unit whose value is a cell of the values of two input units <code>a</code> and\n<code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a unit.</p>\n\n<p><code>b</code> is a unit.</p>\n\n<h2>Produces</h2>\n\n<p>A unit of the two initial values.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  both                                                ::  all the above\n  |*  {a/(unit) b/(unit)}\n  ?~  a  ~\n  ?~  b  ~\n  [~ u=[u.a u.b]]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (both (some 1) (some %b))\n[~ u=[1 %b]]\n&gt; (both ~ (some %b))\n~\n</code></pre>"
+  },
+  {
+    "keys": [
+      "clap"
+    ],
+    "doc": "<h1><code>++clap</code></h1>\n\n<p>Apply function to two units</p>\n\n<p>Applies a binary function <code>c</code>--which does not usually accept or produce a <code>++unit</code>--\nto the values of two units, <code>a</code> and <code>b</code>, producing a unit.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a unit.</p>\n\n<p><code>b</code> is a unit.</p>\n\n<p><code>c</code> is a function that performs a binary operation.</p>\n\n<h2>Produces</h2>\n\n<p>A unit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  clap                                                ::  combine\n  |*  {a/(unit) b/(unit) c/_|=(^ +&lt;-)}\n  ?~  a  b\n  ?~  b  a\n  [~ u=(c u.a u.b)]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =u ((unit @t) [~ 'a'])\n&gt; =v ((unit @t) [~ 'b'])\n&gt; (clap u v |=([a=@t b=@t] (welp (trip a) (trip b))))\n[~ u=\"ab\"] \n&gt; =a ((unit @u) [~ 1])\n&gt; =b ((unit @u) [~ 2])\n&gt; =c |=([a=@ b=@] (add a b))\n&gt; (clap a b c)\n[~ 3]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "drop"
+    ],
+    "doc": "<h1><code>++drop</code></h1>\n\n<p>Unit to list</p>\n\n<p>Makes a ++list of the unwrapped value (<code>u.a</code>) of a <code>++unit</code> <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a unit.</p>\n\n<h2>Produces</h2>\n\n<p>A list.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  drop                                                ::  enlist\n  |*  a/(unit)\n  ?~  a  ~\n  [i=u.a t=~]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a ((unit @) [~ 97])\n&gt; (drop a)\n[i=97 t=~] \n&gt; =a ((unit @) [~])\n&gt; (drop a)\n~\n</code></pre>"
+  },
+  {
+    "keys": [
+      "fall"
+    ],
+    "doc": "<h1><code>++fall</code></h1>\n\n<p>Give unit a default value</p>\n\n<p>Produces a default value <code>b</code> for a <code>++unit</code> <code>a</code> in cases where <code>a</code> is null.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a unit.</p>\n\n<p><code>b</code> is a noun that's used as the default value.</p>\n\n<h2>Produces</h2>\n\n<p>Either a noun <code>b</code> or the unwrapped value of unit <code>a</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  fall                                                ::  default\n  |*  {a/(unit) b/*}\n  ?~(a b u.a)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (fall ~ `a`)\n`a`\n&gt; (fall [~ u=0] `a`)\n0\n</code></pre>"
+  },
+  {
+    "keys": [
+      "lift"
+    ],
+    "doc": "<h1><code>++lift</code></h1>\n\n<p>Curried bind</p>\n\n<p>Accepts a <code>++gate</code> <code>a</code> and produces a function that accepts <code>++unit</code>\n<code>b</code> to which it applies <code>a</code>. Used when you want a function that does not accept\nor produce a unit to both accept and produce a unit.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a gate.</p>\n\n<p><code>b</code> is a unit.</p>\n\n<h2>Produces</h2>\n\n<p>A unit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  lift                                                ::  lift gate (fmap)\n  |*  a/gate                                            ::  flipped\n  |*  b/(unit)                                          ::  curried\n  (bind b a)                                            ::  bind\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((lift dec) `(unit @)`~)\n~\n&gt; ((lift dec) `(unit @)`[~ 20])\n[~ 19]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mate"
+    ],
+    "doc": "<h1><code>++mate</code></h1>\n\n<p>Choose</p>\n\n<p>Accepts two units <code>a</code> and <code>b</code> whose values are expected to be\nequivalent. If either is empty, then the value of the other is produced.\nIf neither are empty, it asserts that both values are the same and\nproduces that value. If the assertion fails, <code>++mate</code> crashes with\n<code>'mate'</code> in the stack trace.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a unit.</p>\n\n<p><code>b</code> is a unit.</p>\n\n<h2>Produces</h2>\n\n<p>A unit or crash.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mate                                                ::  choose\n  |*  {a/(unit) b/(unit)}\n  ?~  b  a\n  ?~  a  b\n  ?.(=(u.a u.b) ~|('mate' !!) a)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a ((unit @) [~ 97])\n&gt; =b ((unit @) [~ 97])\n&gt; (mate a b)\n[~ 97]\n&gt; =a ((unit @) [~ 97])\n&gt; =b ((unit @) [~])\n&gt; (mate a b)\n[~ 97]\n&gt; =a ((unit @) [~ 97])\n&gt; =b ((unit @) [~ 98])\n&gt; (mate a b)\n! 'mate'\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "need"
+    ],
+    "doc": "<h1><code>++need</code></h1>\n\n<p>Unwrap unit</p>\n\n<p>Retrieve the value from a <code>++unit</code> and crash if the unit is null.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a unit.</p>\n\n<h2>Produces</h2>\n\n<p>Either the unwrapped value of <code>a</code> (<code>u.a</code>), or crash.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  need                                                ::  demand\n  |*  a/(unit)\n  ?~  a  ~|(%need !!)\n  u.a\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a ((unit [@t @t]) [~ ['a' 'b']])\n&gt; (need a)\n['a' 'b']\n&gt; =a ((unit @ud) [~ 17])\n&gt; (need a)\n17\n&gt; =a ((unit @) [~])\n&gt; (need a)\n! exit\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "flop"
+    ],
+    "doc": "<h1><code>++flop</code></h1>\n\n<p>Produces the list <code>a</code> in reverse order.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>A list.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  flop                                                ::  reverse\n  ~/  %flop\n  |*  a/(list)\n  =&gt;  .(a (homo a))\n  ^+  a\n  =+  b=`_a`~\n  |-\n  ?~  a  b\n  $(a t.a, b [i.a b])\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a (limo [1 2 3 ~])\n&gt; (flop a)\n~[3 2 1]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "homo"
+    ],
+    "doc": "<h1><code>++homo</code></h1>\n\n<p>Homogenize</p>\n\n<p>Produces a <code>++list</code> whose type is a fork of all the contained types in the\nlist <code>a</code>. Used when you want to make all the types of the elements of a list the same.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>a list. </p>\n\n<h2>Source</h2>\n\n<pre><code>++  homo                                                ::  homogenize\n  |*  a/(list)\n  ^+  =&lt;  $\n    |%  +-  $  ?:(*? ~ [i=(snag 0 a) t=$])\n    --\n  a\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; lyst\n[i=1 t=[i=97 t=[i=2 t=[i=98 t=[i=[~ u=10] t=~]]]]]\n&gt; (homo lyst)\n~[1 97 2 98 [~ u=10]]\n&gt; =a (limo [1 2 3 ~])\n&gt; a\n[i=1 t=[i=2 t=[i=3 t=~]]]\n&gt; (homo a)\n~[1 2 3]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "lent"
+    ],
+    "doc": "<h1><code>++lent</code></h1>\n\n<p>List length</p>\n\n<p>Produces the length of any <code>++list</code> <code>a</code> as an atom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  lent                                                ::  length\n  ~/  %lent\n  |=  a/(list)\n  ^-  @\n  =+  b=0\n  |-\n  ?~  a  b\n  $(a t.a, b +(b))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (lent (limo [1 2 3 4 ~]))\n4\n&gt; (lent (limo [1 'a' 2 'b' (some 10) ~]))\n5\n</code></pre>"
+  },
+  {
+    "keys": [
+      "find"
+    ],
+    "doc": "<h1><code>++find</code></h1>\n\n<p>First index in list</p>\n\n<p>Produces the index of the first occurrence of <code>++list</code> <code>nedl</code> in\n<code>++list</code> <code>hstk</code> as the <code>++unit</code> of an atom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>nedl</code> is a list.</p>\n\n<p><code>hstk</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>The <code>++unit</code> of an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  find                                                ::  first index\n  ~/  %find\n  |=  {nedl/(list) hstk/(list)}\n  =|  i/@ud\n  |-   ^-  (unit @ud)\n  =+  [n=nedl h=hstk]\n  |-\n  ?:  |(?=($~ n) ?=($~ h))\n     ~\n  ?:  =(i.n i.h)\n    ?~  t.n\n      `i\n    $(n t.n, h t.h)\n  ^$(i +(i), hstk +.hstk)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (find [3]~ ~[1 2 3])\n[~ 2]\n&gt; (find [4]~ ~[1 2 3])\n~\n&gt; (find ['a']~ \"cbabab\")\n[~ 2]\n&gt; (find \"ab\" \"cbabab\")\n[~ 2]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "fand"
+    ],
+    "doc": "<h1><code>++fand</code></h1>\n\n<p>All indices in list</p>\n\n<p>Produces the indices of all occurrences of <code>++list</code> <code>nedl</code> in\n<code>++list</code> <code>hstk</code> as a <code>++list</code> of atoms.</p>\n\n<h2>Accepts</h2>\n\n<p><code>nedl</code> is a list.</p>\n\n<p><code>hstk</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++list</code> of atoms.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  fand                                                ::  all indices\n  ~/  %fand\n  |=  {nedl/(list) hstk/(list)}\n  =|  i/@ud\n  =|  fnd/(list @ud)\n  |-  ^+  fnd\n  =+  [n=nedl h=hstk]\n  |-\n  ?:  |(?=($~ n) ?=($~ h))\n    (flop fnd)\n  ?:  =(i.n i.h)\n    ?~  t.n\n      ^$(i +(i), hstk +.hstk, fnd [i fnd])\n    $(n t.n, h t.h)\n  ^$(i +(i), hstk +.hstk)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (fand [3]~ ~[1 2 3])\n~[2]\n&gt; (fand [4]~ ~[1 2 3])\n~\n&gt; (fand ['a']~ \"cbabab\")\n~[2 4]\n&gt; (fand \"ab\" \"cbabab\")\n~[2 4]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "levy"
+    ],
+    "doc": "<h1><code>++levy</code></h1>\n\n<p>Logical \"and\" on list</p>\n\n<p>Computes the Boolean logical \"and\" on the results of gate <code>b</code> applied to each individual element in <code>++list</code> <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a list.</p>\n\n<p><code>b</code> is a gate.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  levy\n  ~/  %levy                                             ::  all of\n  |*  {a/(list) b/$-(* ?)}\n  |-  ^-  ?\n  ?~  a  &amp;\n  ?.  (b i.a)  |\n  $(a t.a)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a |=(a/@ (lte a 1))\n&gt; (levy (limo [0 1 2 1 ~]) a)\n%.n\n&gt; =a |=(a/@ (lte a 3))\n&gt; (levy (limo [0 1 2 1 ~]) a)\n%.y\n</code></pre>"
+  },
+  {
+    "keys": [
+      "lien"
+    ],
+    "doc": "<h1><code>++lien</code></h1>\n\n<p>Logical \"or\" on list</p>\n\n<p>Computes the Boolean logical \"or\" on the results of applying <a href=\"\">gate</a> <code>b</code> to every element of <a href=\"\"><code>++list</code></a> <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a list.</p>\n\n<p><code>b</code> is a gate.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  lien                                                ::  some of\n  ~/  %lien\n  |*  {a/(list) b/$-(* ?)}\n  |-  ^-  ?\n  ?~  a  |\n  ?:  (b i.a)  &amp;\n  $(a t.a)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a |=(a=@ (gte a 1))\n&gt; (lien (limo [0 1 2 1 ~]) a)\n%.y\n&gt; =a |=(a=@ (gte a 3))\n&gt; (lien (limo [0 1 2 1 ~]) a)\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "limo"
+    ],
+    "doc": "<h1><code>++limo</code></h1>\n\n<p>List Constructor</p>\n\n<p>Turns a null-terminated tuple into a <a href=\"\"><code>++list</code></a>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a null-terminated tuple.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++list</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  limo                                                ::  listify\n  |*  a=*\n  ^+  =&lt;  $\n    |%  +-  $  ?~(a ~ ?:(_? i=-.a t=$ $(a +.a)))\n    --\n  a\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (limo [1 2 3 ~])\n[i=1 t=[i=2 t=[i=3 t=~]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "murn"
+    ],
+    "doc": "<h1><code>++murn</code></h1>\n\n<p>Maybe transform</p>\n\n<p>Passes each member of <code>++list</code> <code>a</code> to gate <code>b</code>, which must produce a\n<code>++unit</code>.  Produces a new list with all the results that do not produce\n<code>~</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a list.</p>\n\n<p><code>b</code> is a gate that produces a unit.</p>\n\n<h2>Produces</h2>\n\n<p>A unit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  murn                                                ::  maybe transform\n  ~/  %murn\n  |*  {a/(list) b/$-(* (unit))}\n  |-\n  ?~  a  ~\n  =+  c=(b i.a)\n  ?~  c\n    $(a t.a)\n  [i=u.c t=$(a t.a)]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a |=(a=@ ?.((gte a 2) ~ (some (add a 10))))\n&gt; (murn (limo [0 1 2 3 ~]) a)\n[i=12 t=[i=13 t=~]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "oust"
+    ],
+    "doc": "<h1><code>++oust</code></h1>\n\n<p>Remove</p>\n\n<p>Removes elements from list <code>c</code> beginning at inclusive index <code>a</code>, removing <code>b</code> number of elements.</p>\n\n<h2>Accepts</h2>\n\n<p><code>c</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++list</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  oust                                                ::  remove\n  ~/  %oust\n  |*  {{a/@ b/@} c/(list)}\n  (weld (scag a c) (slag (add a b) c))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (oust [4 5] \"good day, urbit!\")\n\"good urbit!\"\n&gt; (oust [2 2] (limo [1 2 3 4 ~]))\n[i=1 t=[i=2 t=~]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "reap"
+    ],
+    "doc": "<h1><code>++reap</code></h1>\n\n<p>Replicate</p>\n\n<p>Replicate: produces a <code>++list</code> containing <code>a</code> copies of <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A list. </p>\n\n<h2>Source</h2>\n\n<pre><code>++  reap                                                ::  replicate\n  ~/  %reap\n  |*  {a/@ b/*}\n  |-  ^-  (list _b)\n  ?~  a  ~\n  [b $(a (dec a))]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (reap 20 %a)\n~[%a %a %a %a %a %a %a %a %a %a %a %a %a %a %a %a %a %a %a %a]\n&gt; (reap 5 ~s1)\n~[~s1 ~s1 ~s1 ~s1 ~s1]\n&gt; `@dr`(roll (reap 5 ~s1) add)\n~s5\n</code></pre>"
+  },
+  {
+    "keys": [
+      "reel"
+    ],
+    "doc": "<h1><code>++reel</code></h1>\n\n<p>Right fold</p>\n\n<p>Right fold: moves right to left across a <code>++list</code> <code>a</code>, recursively slamming\na binary gate <code>b</code> with an element from <code>a</code> and an accumulator, producing\nthe final value of the accumulator.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a binary gate.</p>\n\n<h2>Produces</h2>\n\n<p>The accumulator, which is a noun.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  reel                                                ::  right fold\n  ~/  %reel\n  |*  {a/(list) b/_|=({* *} +&lt;+)}\n  |-  ^+  +&lt;+.b\n  ?~  a\n    +&lt;+.b\n  (b i.a $(a t.a))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =sum =|([p=@ q=@] |.((add p q)))\n&gt; (reel (limo [1 2 3 4 5 ~]) sum)\n15\n&gt; =a =|([p=@ q=@] |.((sub p q)))\n&gt; (reel (limo [6 3 1 ~]) a)\n4\n&gt; (reel (limo [3 6 1 ~]) a)\n! subtract-underflow\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "roll"
+    ],
+    "doc": "<h1><code>++roll</code></h1>\n\n<p>Left fold</p>\n\n<p>Left fold: moves left to right across a list <code>a</code>, recursively slamming a\nbinary <a href=\"\">gate</a> <code>b</code> with an element from the <a href=\"\"><code>++list</code></a> and an accumulator,\nproducing the final value of the accumulator.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a binary <a href=\"\">gate</a>.</p>\n\n<h2>Produces</h2>\n\n<p>The accumulator, which is a <a href=\"\">noun</a>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  roll                                                ::  left fold\n  ~/  %roll\n  |*  [a=(list) b=_|=([* *] +&lt;+)]\n  |-  ^+  +&lt;+.b\n  ?~  a\n    +&lt;+.b\n  $(a t.a, b b(+&lt;+ (b i.a +&lt;+.b)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =sum =|([p=@ q=@] |.((add p q)))\n&gt; (roll (limo [1 2 3 4 5 ~]) sum)\nq=15\n&gt; =a =|([p=@ q=@] |.((sub p q)))\n&gt; (roll (limo [6 3 1 ~]) a)\n! subtract-underflow\n! exit\n&gt; (roll (limo [1 3 6 ~]) a)\nq=4\n</code></pre>"
+  },
+  {
+    "keys": [
+      "scag"
+    ],
+    "doc": "<h1><code>++scag</code></h1>\n\n<p>Prefix</p>\n\n<p>Accepts an atom <code>a</code> and <a href=\"\">list</a> <code>b</code>, producing the first <code>a</code> elements of\nthe front of the list.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>A list of the same type as <code>b</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  scag                                                ::  prefix\n  ~/  %scag\n  |*  [a=@ b=(list)]\n  |-  ^+  b\n  ?:  |(?=(~ b) =(0 a))  ~\n  [i.b $(b t.b, a (dec a))]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scag 2 (limo [0 1 2 3 ~]))\n[i=0 t=[i=1 t=~]]\n&gt; (scag 10 (limo [1 2 3 4 ~]))\n[i=1 t=[i=2 t=[i=3 t=[i=4 t=~]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "skid"
+    ],
+    "doc": "<h1><code>++skid</code></h1>\n\n<p>Separate</p>\n\n<p>Separates a <code>++list</code> <code>a</code> into two lists - Those elements of <code>a</code> who produce\ntrue when slammed to gate <code>b</code> and those who produce <code>%.n</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a gate that accepts one argument and produces a loobean.</p>\n\n<h2>Produces</h2>\n\n<p>A cell of two lists.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  skid                                                ::  separate\n  ~/  %skid\n  |*  {a/(list) b/$-(* ?)}\n  |-  ^+  [p=a q=a]\n  ?~  a  [~ ~]\n  =+  c=$(a t.a)\n  ?:((b i.a) [[i.a p.c] q.c] [p.c [i.a q.c]])\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a |=(a/@ (gth a 1))\n&gt; (skid (limo [0 1 2 3 ~]) a)\n[p=[i=2 t=[i=3 t=~]] q=[i=0 t=[i=1 t=~]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "skim"
+    ],
+    "doc": "<h1><code>++skim</code></h1>\n\n<p>Suffix</p>\n\n<p>Cycles through the members of a list <code>a</code>, passing them to a gate <code>b</code> and\nproducing a list of all of the members that produce <code>%.y</code>. Inverse of\n<code>++skip</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a gate that accepts one argument and produces a boolean.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean</p>\n\n<h2>Source</h2>\n\n<pre><code>++  skim                                                ::  only\n  ~/  %skim\n  |*  {a/(list) b/$-(* ?)}\n  |-\n  ^+  a\n  ?~  a  ~\n  ?:((b i.a) [i.a $(a t.a)] $(a t.a))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a |=(a/@ (gth a 1))\n&gt; (skim (limo [0 1 2 3 ~]) a)\n[i=2 t=[i=3 t=~]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "skip"
+    ],
+    "doc": "<h1><code>++skip</code></h1>\n\n<p>Except</p>\n\n<p>Cycles through the members of <code>++list</code> <code>a</code>, passing them to a gate <code>b</code>. \nProduces a list of all of the members that produce <code>%.n</code>. Inverse of\n<code>++skim</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a gate that accepts one argument and produces a loobean.</p>\n\n<h2>Produces</h2>\n\n<p>A list of the same type as <code>a</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  skip                                                ::  except\n  ~/  %skip\n  |*  {a/(list) b/$-(* ?)}\n  |-\n  ^+  a\n  ?~  a  ~\n  ?:((b i.a) $(a t.a) [i.a $(a t.a)])\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a |=(a/@ (gth a 1))\n&gt; (skip (limo [0 1 2 3 ~]) a)\n[i=0 t=[i=1 t=~]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "slag"
+    ],
+    "doc": "<h1><code>++slag</code></h1>\n\n<p>Suffix</p>\n\n<p>Accepts an atom <code>a</code> and list <code>b</code>, producing the remaining elements from\n<code>b</code> starting at <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>A list of the same type as <code>b</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  slag                                                ::  suffix\n  ~/  %slag\n  |*  {a/@ b/(list)}\n  |-  ^+  b\n  ?:  =(0 a)  b\n  ?~  b  ~\n  $(b t.b, a (dec a))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (slag 2 (limo [1 2 3 4 ~]))\n[i=3 t=[i=4 t=~]]\n&gt; (slag 1 (limo [1 2 3 4 ~]))\n[i=2 t=[i=3 t=[i=4 t=~]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "snag"
+    ],
+    "doc": "<h1><code>++snag</code></h1>\n\n<p>Index</p>\n\n<p>Accepts an atom <code>a</code> and a <code>++list</code> <code>b</code>, producing the element at the index\nof <code>a</code>and failing if the list is null. Lists are 0-indexed.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>Produces an element of <code>b</code>, or crashes if no element exists at that index.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  snag                                                ::  index\n  ~/  %snag\n  |*  {a/@ b/(list)}\n  |-\n  ?~  b\n    ~|('snag-fail' !!)\n  ?:  =(0 a)  i.b\n  $(b t.b, a (dec a))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (snag 2 \"asdf\")\n~~d\n&gt; (snag 0 `(list @ud)`~[1 2 3 4])\n1\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sort"
+    ],
+    "doc": "<h1><code>++sort</code></h1>\n\n<p>Quicksort</p>\n\n<p>Quicksort: accepts a <code>++list</code> <code>a</code> and a gate <code>b</code> which accepts two nouns and\nproduces a loobean. <code>++sort</code> then produces a list of the elements of <code>a</code>,\nsorted according to <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a gate that accepts two nouns and produces a boolean.</p>\n\n<h2>Produces</h2>\n\n<p>A list</p>\n\n<h2>Source</h2>\n\n<pre><code>++  sort   !.                                           ::  quicksort\n  ~/  %sort\n  |*  {a/(list) b/$-([* *] ?)}\n  =&gt;  .(a ^.(homo a))\n  |-  ^+  a\n  ?~  a  ~\n  %+  weld\n    $(a (skim t.a |=(c/_i.a (b c i.a))))\n  ^+  t.a\n  [i.a $(a (skim t.a |=(c/_i.a !(b c i.a))))]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; =a =|({p=@ q=@} |.((gth p q)))\n    &gt; (sort (limo [0 1 2 3 ~]) a)\n    ~[3 2 1 0]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "swag"
+    ],
+    "doc": "<h1><code>++swag</code></h1>\n\n<p>Infix</p>\n\n<p>Similar to <code>substr</code> in Javascript: extracts a string infix, beginning at\ninclusive index <code>a</code>, producing <code>b</code> number of characters.</p>\n\n<h2>Accepts</h2>\n\n<p><code>c</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>A list of the same type as <code>c</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  swag                                                ::  infix\n  |*  {{a/@ b/@} c/(list)}\n  (scag +&lt;-&gt; (slag +&lt;-&lt; c))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (swag [2 5] \"roly poly\")\n\"ly po\"\n&gt; (swag [2 2] (limo [1 2 3 4 ~]))\n[i=3 t=[i=4 t=~]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "turn"
+    ],
+    "doc": "<h1><code>++turn</code></h1>\n\n<p>Gate to list</p>\n\n<p>Accepts a <code>++list</code> <code>a</code> and a gate <code>b</code>. Produces a list with the gate applied\nto each element of the original list.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a gate.</p>\n\n<h2>Produces</h2>\n\n<p>A list.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  turn                                                ::  transform\n  ~/  %turn\n  |*  {a/(list) b/$-(* *)}\n  |-\n  ?~  a  ~\n  [i=(b i.a) t=$(a t.a)]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (turn (limo [104 111 111 110 ~]) @t)\n&lt;|h o o n|&gt;\n&gt; =a |=(a/@ (add a 4))\n&gt; (turn (limo [1 2 3 4 ~]) a)\n~[5 6 7 8]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "spin"
+    ],
+    "doc": "<h1><code>++spin</code></h1>\n\n<p>Gate to list, with state</p>\n\n<p>Accepts a <code>++list</code> <code>a</code>, a gate <code>b</code>, and some state <code>c</code>. Produces a list with\nthe gate applied to each element of the original list. <code>b</code> is called with\na tuple -- the head is an element of <code>a</code> and the tail is the state <code>c</code>, and\nshould produce a tuple of the transformed element and the (potentially\nmodified) state <code>c</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++list</code>.</p>\n\n<p><code>b</code> is a gate.</p>\n\n<p><code>c</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A list.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  spin\n  |*  {a/(list) b/_|=({* *} [** +&lt;+]) c/*}\n  ::  ?&lt;  ?=($-([_?&lt;(?=($~ a) i.a) _c] [* _c]) b)\n  |-\n  ?~  a\n    ~\n  =+  v=(b i.a c)\n  [i=-.v t=$(a t.a, c +.v)]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>A trivial example -- does nothing with the state:</p>\n\n<pre><code>&gt; %^  spin  (limo ~[4 5 6])\n    |=({n/@ a/@} [n a])\n  0\n~[4 5 6]\n</code></pre>\n\n<p>Create a list of pairs, <code>p</code> as the index and <code>q</code> as the list element:</p>\n\n<pre><code>&gt; %^  spin  (limo ~[4 5 6])\n    |=({n/@ a/@} [`(pair)`[a n] +(a)])\n  0\n~[[p=0 q=4] [p=1 q=5] [p=2 q=6]]\n</code></pre>\n\n<p>Create 10 random numbers less than <code>10</code>:</p>\n\n<pre><code>&gt; %^  spin  (reap 10 0)\n    |=({n/@ rng/_og} (rads:rng 10))\n  ~(. og eny)\n~[5 5 9 4 1 7 9 9 9 6]\n</code></pre>\n\n<p><em>Notes</em>:</p>\n\n<p><code>(~(rads og eny) 2)</code> creates a random number less than <code>2</code>, seeding the RNG\nwith entropy (<code>eny</code>). The head of the product is the random number, the tail\nis the continuation of the RNG.</p>"
+  },
+  {
+    "keys": [
+      "spun"
+    ],
+    "doc": "<h1><code>++spun</code></h1>\n\n<p>Gate to list, with state</p>\n\n<p>Accepts a <code>++list</code> <code>a</code> and a gate <code>b</code>. <code>c</code> is internal state, initially\nderived by <em>bunting</em> the tail of the sample of gate <code>b</code>, instead of\nbeing passed in explicitly as in <code>++spin</code>. Produces a list with the\ngate applied to each element of the original list. <code>b</code> is called with a tuple\n-- the head is an element of <code>a</code> and the tail is the state <code>c</code>, and should\nproduce a tuple of the transformed element and the (potentially modified)\nstate <code>c</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++list</code>.</p>\n\n<p><code>b</code> is a gate.</p>\n\n<h2>Produces</h2>\n\n<p>A list.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  spun\n  |*  {a/(list) b/_|=({* *} [** +&lt;+])}\n  =|  c/_+&lt;+.b\n  |-\n  ?~  a\n    ~\n  =+  v=(b i.a c)\n  [i=-.v t=$(a t.a, c +.v)]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>Create a list of pairs, <code>p</code> as the index and <code>q</code> as the list element:</p>\n\n<pre><code>&gt; %+  spun  (limo ~[4 5 6])\n  |=({n/@ a/@} [`(pair)`[a n] +(a)])\n~[[p=0 q=4] [p=1 q=5] [p=2 q=6]]\n</code></pre>\n\n<p>Join two lists into a list of pairs, <code>p</code> from <code>l</code> and <code>q</code> from the sample:</p>\n\n<pre><code>&gt; =l (limo ~[7 8 9])\n&gt; %+  spun  (limo ~[4 5 6])\n  |=({n/@ a/@} [`(pair)`[(snag a l) n] +(a)])\n~[[p=7 q=4] [p=8 q=5] [p=9 q=6]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "weld"
+    ],
+    "doc": "<h1><code>++weld</code></h1>\n\n<p>Concatenate</p>\n\n<p>Concatenate two <code>++list</code>s <code>a</code> and <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> and <code>b</code> are lists.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  weld                                                ::  concatenate\n  ~/  %weld\n  |*  {a/(list) b/(list)}\n  =&gt;  .(a ^.(homo a), b ^.(homo b))\n  |-  ^+  b\n  ?~  a  b\n  [i.a $(a t.a)]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (weld \"urb\" \"it\")\n~[~~u ~~r ~~b ~~i ~~t]\n&gt; (weld (limo [1 2 ~]) (limo [3 4 ~]))\n~[1 2 3 4]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "welp"
+    ],
+    "doc": "<h1><code>++welp</code></h1>\n\n<p>Perfect weld</p>\n\n<p>Concatenate two <code>++list</code>s <code>a</code> and <code>b</code> without losing their type information\nto homogenization.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a list.</p>\n\n<p><code>b</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>A list.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  welp                                                ::  perfect weld\n  =|  {* *}\n  |%\n  +-  $\n    ?~  +&lt;-\n      +&lt;-(. +&lt;+)\n    +&lt;-(+ $(+&lt;- +&lt;-&gt;))\n  --\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (welp \"foo\" \"bar\")\n\"foobar\"\n~zod/arvo=/hoon/hoon&gt; (welp ~[60 61 62] ~[%a %b %c])\n[60 61 62 %a %b %c ~]\n~zod/arvo=/hoon/hoon&gt;? (welp ~[60 61 62] ~[%a %b %c])\n[60 61 62 %a %b %c ~]\n[@ud @ud @ud %a %b %c %~]\n~zod/arvo=/hoon/hoon&gt; (welp [sa+1 so+2 ~] si/3)\n[[%sa 1] [%so 2] %si 3]\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "bex"
+    ],
+    "doc": "<h1><code>++bex</code></h1>\n\n<p>Binary exponent</p>\n\n<p>Computes the result of <code>2^a</code>, producing an atom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bex                                                 ::  binary exponent\n  ~/  %bex\n  |=  a/@\n  ^-  @\n  ?:  =(0 a)  1\n  (mul 2 $(a (dec a)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (bex 4)\n16\n&gt; (bex (add 19 1))\n1.048.576\n&gt; (bex 0)\n1\n</code></pre>"
+  },
+  {
+    "keys": [
+      "can"
+    ],
+    "doc": "<h1><code>++can</code></h1>\n\n<p>Assemble</p>\n\n<p>Produces an atom from a list <code>b</code> of length-value pairs <code>p</code> and <code>q</code>,\nwhere <code>p</code> is the length in bloqs of size <code>a</code>, and <code>q</code> is an atomic\nvalue.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is a <code>++list</code> of length value pairs, <code>p</code> and <code>q</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  can                                                 ::  assemble\n  ~/  %can\n  |=  [a/bloq b/(list [p=@ q=@])]\n  ^-  @\n  ?~  b  0\n  (mix (end a p.i.b q.i.b) (lsh a p.i.b $(b t.b)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`(can 3 ~[[1 1]])\n0b1 \n&gt; `@ub`(can 0 ~[[1 255]])\n0b1\n&gt; `@ux`(can 3 [3 0xc1] [1 0xa] ~)\n0xa00.00c1\n&gt; `@ux`(can 3 [3 0xc1] [1 0xa] [1 0x23] ~)\n0x23.0a00.00c1\n&gt; `@ux`(can 4 [3 0xc1] [1 0xa] [1 0x23] ~)\n0x23.000a.0000.0000.00c1\n&gt; `@ux`(can 3 ~[[1 'a'] [2 'bc']])\n0x63.6261\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cat"
+    ],
+    "doc": "<h1><code>++cat</code></h1>\n\n<p>Concatenate</p>\n\n<p>Concatenates two atoms, <code>b</code> and <code>c</code>, according to bloq size <code>a</code>, producing an\natom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cat                                                 ::  concatenate\n  ~/  %cat\n  |=  {a/bloq b/@ c/@}\n  (add (lsh a (met a b) c) b)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`(cat 3 1 0)\n0b1\n&gt; `@ub`(cat 0 1 1)\n0b11\n&gt; `@ub`(cat 0 2 1)\n0b110\n&gt; `@ub`(cat 2 1 1)\n0b1.0001\n&gt; `@ub`256\n0b1.0000.0000\n&gt; `@ub`255\n0b1111.1111\n&gt; `@ub`(cat 3 256 255)\n0b1111.1111.0000.0001.0000.0000\n&gt; `@ub`(cat 2 256 255)\n0b1111.1111.0001.0000.0000\n&gt; (cat 3 256 255)\n16.711.936\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cut"
+    ],
+    "doc": "<h1><code>++cut</code></h1>\n\n<p>Slice</p>\n\n<p>Slices <code>c</code> blocks of size <code>a</code> that are <code>b</code> blocks from the end of <code>d</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see ++bloq).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cut                                                 ::  slice\n  ~/  %cut\n  |=  {a/bloq {b/@u c/@u} d/@}\n  (end a c (rsh a b d))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (cut 0 [1 1] 2)\n1\n&gt; (cut 0 [2 1] 4)\n1\n&gt; `@t`(cut 3 [0 3] 'abcdefgh')\n'abc'\n&gt; `@t`(cut 3 [1 3] 'abcdefgh')\n'bcd'\n&gt; `@ub`(cut 0 [0 3] 0b1111.0000.1101)\n0b101\n&gt; `@ub`(cut 0 [0 6] 0b1111.0000.1101)\n0b1101\n&gt; `@ub`(cut 0 [4 6] 0b1111.0000.1101)\n0b11.0000\n&gt; `@ub`(cut 0 [3 6] 0b1111.0000.1101)\n0b10.0001\n</code></pre>"
+  },
+  {
+    "keys": [
+      "end"
+    ],
+    "doc": "<h1><code>++end</code></h1>\n\n<p>Tail</p>\n\n<p>Produces an atom by taking the last <code>b</code> blocks of size <code>a</code> from <code>c</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  end                                                 ::  tail\n  ~/  %end\n  |=  {a/bloq b/@u c/@}\n  (mod c (bex (mul (bex a) b)))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`12\n0b1100\n&gt; `@ub`(end 0 3 12)\n0b100\n&gt; (end 0 3 12)\n4\n&gt; `@ub`(end 1 3 12)\n0b1100\n&gt; (end 1 3 12)\n12\n&gt; `@ux`'abc'\n0x63.6261\n&gt; `@ux`(end 3 2 'abc')\n0x6261\n&gt; `@t`(end 3 2 'abc')\n'ab'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "fil"
+    ],
+    "doc": "<h1><code>++fil</code></h1>\n\n<p>Fill bloqstream</p>\n\n<p>Produces an atom by repeating <code>c</code> for <code>b</code> blocks of size <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  fil                                                 ::  fill bloqstream\n  |=  {a/bloq b/@u c/@}\n  =+  n=0\n  =+  d=c\n  |-  ^-  @\n  ?:  =(n b)\n    (rsh a 1 d)\n  $(d (add c (lsh a 1 d)), n +(n))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@t`(fil 3 5 %a)\n'aaaaa'\n&gt; `@t`(fil 5 10 %ceeb)\n'ceebceebceebceebceebceebceebceebceebceeb'\n&gt; `@t`(fil 4 10 %eced)\n'ʇʇʇʇʇʇʇʇʇʇed'\n&gt; `@tas`(fil 4 10 %bf)\n%bfbfbfbfbfbfbfbfbfbf\n</code></pre>"
+  },
+  {
+    "keys": [
+      "lsh"
+    ],
+    "doc": "<h1><code>++lsh</code></h1>\n\n<p>Left-shift</p>\n\n<p>Produces an atom by left-shifting <code>c</code> by <code>b</code> blocks of size <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  lsh                                                 ::  left-shift\n  ~/  %lsh\n  |=  {a/bloq b/@u c/@}\n  (mul (bex (mul (bex a) b)) c)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`1\n0b1\n&gt; `@ub`(lsh 0 1 1)\n0b10\n&gt; (lsh 0 1 1)\n2\n&gt; `@ub`255\n0b1111.1111\n&gt; `@ub`(lsh 3 1 255)\n0b1111.1111.0000.0000\n&gt; (lsh 3 1 255)\n65.280\n</code></pre>"
+  },
+  {
+    "keys": [
+      "met"
+    ],
+    "doc": "<h1><code>++met</code></h1>\n\n<p>Measure</p>\n\n<p>Computes the number of blocks of size <code>a</code> in <code>b</code>, producing an atom.</p>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  met                                                 ::  measure\n  ~/  %met\n  |=  {a/bloq b/@}\n  ^-  @\n  =+  c=0\n  |-\n  ?:  =(0 b)  c\n  $(b (rsh a 1 b), c +(c))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (met 0 1)\n1\n&gt; (met 0 2)\n2\n&gt; (met 3 255)\n1\n&gt; (met 3 256)\n2\n&gt; (met 3 'abcde')\n5\n</code></pre>"
+  },
+  {
+    "keys": [
+      "rap"
+    ],
+    "doc": "<h1><code>++rap</code></h1>\n\n<p>Assemble non-zero</p>\n\n<p>Concatenates a list of atoms <code>b</code> using blocksize <code>a</code>, producing an atom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is a <code>++list</code> of atoms.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  rap                                                 ::  assemble nonzero\n  ~/  %rap\n  |=  {a/bloq b/(list @)}\n  ^-  @\n  ?~  b  0\n  (cat a i.b $(b t.b))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`(rap 2 (limo [1 2 3 4 ~]))\n0b100.0011.0010.0001\n&gt; `@ub`(rap 1 (limo [1 2 3 4 ~]))\n0b1.0011.1001\n&gt; (rap 0 (limo [0 0 0 ~]))\n0\n&gt; (rap 0 (limo [1 0 1 ~]))\n3\n</code></pre>"
+  },
+  {
+    "keys": [
+      "rep"
+    ],
+    "doc": "<h1><code>++rep</code></h1>\n\n<p>Assemble single</p>\n\n<p>Produces an atom by assembling a list of atoms <code>b</code> using block size <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is a list of atoms.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  rep                                                 ::  assemble single\n  ~/  %rep\n  |=  {a/bloq b/(list @)}\n  ^-  @\n  =+  c=0\n  |-\n  ?~  b  0\n  (con (lsh a c (end a 1 i.b)) $(c +(c), b t.b))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`(rep 2 (limo [1 2 3 4 ~]))\n0b100.0011.0010.0001\n&gt; (rep 0 (limo [0 0 1 ~]))\n4\n&gt; (rep 0 (limo [0 0 0 1 ~]))\n8\n&gt; (rep 0 (limo [0 1 0 0 ~]))\n2\n&gt; (rep 0 (limo [0 1 0 1 ~]))\n10\n&gt; (rep 0 (limo [0 1 0 1 0 1 ~]))\n42\n&gt; `@ub`42\n0b10.1010\n</code></pre>"
+  },
+  {
+    "keys": [
+      "rip"
+    ],
+    "doc": "<h1><code>++rip</code></h1>\n\n<p>Disassemble</p>\n\n<p>Produces a list of atoms from the bits of <code>b</code> using block size <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A list of atoms.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  rip                                                 ::  disassemble\n  ~/  %rip\n  |=  {a/bloq b/@}\n  ^-  (list @)\n  ?:  =(0 b)  ~\n  [(end a 1 b) $(b (rsh a 1 b))]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`155\n0b1001.1011\n&gt; (rip 0 155)\n~[1 1 0 1 1 0 0 1]\n&gt; (rip 2 155)\n~[11 9]\n&gt; (rip 1 155)\n~[3 2 1 2]\n&gt; `@ub`256\n0b1.0000.0000\n&gt; (rip 0 256)\n~[0 0 0 0 0 0 0 0 1]\n&gt; (rip 2 256)\n~[0 0 1]\n&gt; (rip 3 256)\n~[0 1]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "rsh"
+    ],
+    "doc": "<h1><code>++rsh</code></h1>\n\n<p>Right-shift</p>\n\n<p>Right-shifts <code>c</code> by <code>b</code> blocks of size <code>a</code>, producing an atom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  rsh                                                 ::  right-shift\n  ~/  %rsh\n  |=  {a/bloq b/@u c/@}\n  (div c (bex (mul (bex a) b)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`145\n0b1001.0001\n&gt; `@ub`(rsh 1 1 145)\n0b10.0100\n&gt; (rsh 1 1 145)\n36\n&gt; `@ub`(rsh 2 1 145)\n0b1001\n&gt; (rsh 2 1 145)\n9\n&gt; `@ub`10\n0b1010\n&gt; `@ub`(rsh 0 1 10)\n0b101\n&gt; (rsh 0 1 10)\n5\n&gt; `@ux`'abc'\n0x63.6261\n&gt; `@t`(rsh 3 1 'abc')\n'bc'\n&gt; `@ux`(rsh 3 1 'abc')\n0x6362\n</code></pre>"
+  },
+  {
+    "keys": [
+      "swp"
+    ],
+    "doc": "<h1><code>++swp</code></h1>\n\n<p>Reverse block order</p>\n\n<p>Switches little endian to big and vice versa: produces an atom by\nreversing the block order of <code>b</code> using block size <code>a</code>.</p>\n\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a block size (see <code>++bloq</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom</p>\n\n<h2>Source</h2>\n\n<pre><code>++  swap  |=({a/bloq b/@} (rep a (flop (rip a b))))     ::  reverse bloq order\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`24\n0b1.1000\n&gt; (swap 0 24)\n3\n&gt; `@ub`3\n0b11\n&gt; (swap 0 0)\n0\n&gt; (swap 0 128)\n1\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "con"
+    ],
+    "doc": "<h1><code>++con</code></h1>\n\n<p>Binary OR</p>\n\n<p>Computes the bit-wise logical OR of two <a href=\"\">atom</a>s, <code>a</code> and <code>b</code>, producing an\natom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom</p>\n\n<p><code>b</code> is an atom</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  con                                                 ::  binary or\n  ~/  %con\n  |=  {a/@ b/@}\n  =+  [c=0 d=0]\n  |-  ^-  @\n  ?:  ?&amp;(=(0 a) =(0 b))  d\n  %=  $\n    a   (rsh 0 1 a)\n    b   (rsh 0 1 b)\n    c   +(c)\n    d   %+  add  d\n          %^  lsh  0  c\n          ?&amp;  =(0 (end 0 1 a))\n              =(0 (end 0 1 b))\n          ==\n  ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (con 0b0 0b1)\n1\n&gt; (con 0 1)\n1\n&gt; (con 0 0)\n0\n&gt; `@ub`(con 0b1111.0000 0b1.0011)\n0b1111.0011    \n&gt; (con 4 4)\n4\n&gt; (con 10.000 234)\n10.234\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dis"
+    ],
+    "doc": "<h1><code>++dis</code></h1>\n\n<p>Binary AND</p>\n\n<p>Computes the bit-wise logical AND of two atoms <code>a</code> and <code>b</code>, producing an\natom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  dis                                                 ::  binary and\n  ~/  %dis\n  |=  {a/@ b/@}\n  =|  {c/@ d/@}\n  |-  ^-  @\n  ?:  ?|(=(0 a) =(0 b))  d\n  %=  $\n    a   (rsh 0 1 a)\n    b   (rsh 0 1 b)\n    c   +(c)\n    d   %+  add  d\n          %^  lsh  0  c\n          ?|  =(0 (end 0 1 a))\n              =(0 (end 0 1 b))\n          ==\n  ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`9\n0b1001\n&gt; `@ub`5\n0b101\n&gt; `@ub`(dis 9 5)\n0b1\n&gt; (dis 9 5)\n1\n&gt; `@ub`534\n0b10.0001.0110\n&gt; `@ub`987\n0b11.1101.1011\n&gt; `@ub`(dis 534 987)\n0b10.0001.0010\n&gt; (dis 534 987)\n530\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mix"
+    ],
+    "doc": "<h1><code>++mix</code></h1>\n\n<p>Binary XOR</p>\n\n<p>Produces the bit-wise logical XOR of <code>a</code> and <code>b</code>, producing an atom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom</p>\n\n<p><code>b</code> is an atom</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mix                                                 ::  binary xor\n  ~/  %mix\n  |=  {a/@ b/@}\n  ^-  @\n  =+  [c=0 d=0]\n  |-\n  ?:  ?&amp;(=(0 a) =(0 b))  d\n  %=  $\n    a   (rsh 0 1 a)\n    b   (rsh 0 1 b)\n    c   +(c)\n    d   (add d (lsh 0 c =((end 0 1 a) (end 0 1 b))))\n  ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ub`2\n0b10\n&gt; `@ub`3\n0b11\n&gt; `@ub`(mix 2 3)\n0b1\n&gt; (mix 2 3)\n1\n&gt; `@ub`(mix 2 2)\n0b0\n&gt; (mix 2 2)\n0\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "fnv"
+    ],
+    "doc": "<h1><code>++fnv</code></h1>\n\n<p>Hashes an atom with the 32-bit FNV non-cryptographic hash algorithm.\nMultiplies <code>a</code> by the prime number 16,777,619 and then takes the block\nof size 5 off the product's end, producing an atom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  fnv  |=(a/@ (end 5 1 (mul 16.777.619 a)))           ::  FNV scrambler\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (fnv 10.000)\n272.465.456\n&gt; (fnv 10.001)\n289.243.075\n&gt; (fnv 1)\n16.777.619\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mug"
+    ],
+    "doc": "<h1><code>++mug</code></h1>\n\n<p>Hashes <code>a</code> with the 31-bit nonzero FNV-1a non-cryptographic hash\nalgorithm, producing an atom.</p>\n\n<h2>Accepts</h2>\n\n<p>A is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mug                                                 ::  31bit nonzero FNV1a\n  ~/  %mug\n  |=  a/*\n  ?^  a\n    =+  b=[p=$(a -.a) q=$(a +.a)]\n    |-  ^-  @\n    =+  c=(fnv (mix p.b (fnv q.b)))\n    =+  d=(mix (rsh 0 31 c) (end 0 31 c))\n    ?.  =(0 c)  c\n    $(q.b +(q.b))\n  =+  b=2.166.136.261\n  |-  ^-  @\n  =+  c=b\n  =+  [d=0 e=(met 3 a)]\n  |-  ^-  @\n  ?:  =(d e)\n    =+  f=(mix (rsh 0 31 c) (end 0 31 c))\n    ?.  =(0 f)  f\n    ^$(b +(b))\n  $(c (fnv (mix c (cut 3 [d 1] a))), d +(d))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mug 10.000)\n178.152.889\n&gt; (mug 10.001)\n714.838.017\n&gt; (mug 1)\n67.918.732\n&gt; (mug (some 10))\n1.872.403.737\n&gt; (mug (limo [1 2 3 4 5 ~]))\n1.067.931.605\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "aor"
+    ],
+    "doc": "<h1><code>++aor</code></h1>\n\n<p>Alphabetic order</p>\n\n<p>Computes whether <code>a</code> and <code>b</code> are in alphabetical order, producing a\nboolean.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a noun.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean atom.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  aor                                                 ::  a-order\n  ~/  %aor\n  |=  {a/* b/*}\n  ^-  ?\n  ?:  =(a b)  &amp;\n  ?.  ?=(@ a)\n    ?:  ?=(@ b)  |\n    ?:  =(-.a -.b)\n      $(a +.a, b +.b)\n    $(a -.a, b -.b)\n  ?.  ?=(@ b)  &amp;\n  |-\n  =+  [c=(end 3 1 a) d=(end 3 1 b)]\n  ?:  =(c d)\n    $(a (rsh 3 1 a), b (rsh 3 1 b))\n  (lth c d)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (aor 'a' 'b')\n%.y\n&gt; (aor 'b' 'a')\n%.n\n&gt; (aor \"foo\" \"bar\")\n%.n\n&gt; (aor \"bar\" \"foo\")\n%.y\n&gt; (aor \"abcdefz\" \"abcdefa\")\n%.n\n&gt; (aor \"abcdefa\" \"abcdefz\")\n%.y\n&gt; (aor 10.000 17.000)\n%.y\n&gt; (aor 10 9)\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dor"
+    ],
+    "doc": "<h1><code>++dor</code></h1>\n\n<p>Numeric order</p>\n\n<p>Computes whether <code>a</code> and <code>b</code> are in ascending numeric order, producing a\nboolean.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a noun.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  dor                                                 ::  d-order\n  ~/  %dor\n  |=  {a/* b/*}\n  ^-  ?\n  ?:  =(a b)  &amp;\n  ?.  ?=(@ a)\n    ?:  ?=(@ b)  |\n    ?:  =(-.a -.b)\n      $(a +.a, b +.b)\n    $(a -.a, b -.b)\n  ?.  ?=(@ b)  &amp;\n  (lth a b)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (dor 1 2)\n%.y\n&gt; (dor 2 1)\n%.n\n&gt; (dor ~[1 2 3] ~[1 2 4])\n%.y\n&gt; (dor ~[1 2 4] ~[1 2 3])\n%.n\n&gt; (dor (limo ~[99 100 10.000]) ~[99 101 10.000])\n%.y\n&gt; (dor ~[99 101 10.999] (limo ~[99 100 10.000]))\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gor"
+    ],
+    "doc": "<h1><code>++gor</code></h1>\n\n<p>Hash order</p>\n\n<p>XX revisit</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a noun.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gor                                                 ::  g-order\n  ~/  %gor\n  |=  {a/* b/*}\n  ^-  ?\n  =+  [c=(mug a) d=(mug b)]\n  ?:  =(c d)\n    (dor a b)\n  (lth c d)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (gor 'd' 'c')\n%.y\n&gt; 'd'\n'd'\n&gt; 'c'\n&gt; `@ud`'d'\n100\n&gt; `@ud`'c'\n99\n&gt; (mug 'd')\n1.628.185.714\n&gt; (mug 'c')\n1.712.073.811\n&gt; (gor 'd' 'c')\n%.y\n&gt; (gor 'c' 'd')\n%.n\n&gt; (gor \"foo\" \"bar\")\n%.n\n&gt; (gor (some 10) (limo [1 2 3 ~]))\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "hor"
+    ],
+    "doc": "<h1><code>++hor</code></h1>\n\n<p>Hash order</p>\n\n<p>XX revisit</p>\n\n<p>Recursive hash comparator gate.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a noun.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean atom. </p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  hor                                                 ::  h-order\n  ~/  %hor\n  |=  {a/* b/*}\n  ^-  ?\n  ?:  ?=(@ a)\n    ?.  ?=(@ b)  &amp;\n    (gor a b)\n  ?:  ?=(@ b)  |\n  ?:  =(-.a -.b)\n    (gor +.a +.b)\n  (gor -.a -.b)\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (hor . 1)\n%.n\n&gt; (hor 1 2)\n%.y\n&gt; (hor \"abc\" \"cba\")\n%.y\n&gt; (hor 'c' 'd')\n%.n\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "in"
+    ],
+    "doc": "<h1><code>++in</code></h1>\n\n<p>Set operations</p>\n\n<p>Core whose arms contain a variety of functions that operate on <code>++set</code>s. Its sample accepts the input <code>++set</code> to be manipulated. </p>\n\n<h2>Accepts</h2>\n\n<p>A <code>++set</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  in                                                  ::  set engine\n  ~/  %in\n  |_  a/(set)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ~(. in (sa \"asd\"))\n&lt;13.evb [nlr(^$1{@tD $1}) &lt;414.fvk 101.jzo 1.ypj %164&gt;]&gt;\n</code></pre>"
+  },
+  {
+    "keys": [
+      "all in"
+    ],
+    "doc": "<h1><code>+-all:in</code></h1>\n\n<p>Logical AND</p>\n\n<p>Computes the logical AND on every element in <code>a</code> slammed with <code>b</code>,\nproducing a boolean.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++set</code>.</p>\n\n<p><code>b</code> is a wet gate that accepts a noun and produces a boolean.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  all                                               ::  logical AND\n    ~/  %all\n    |*  b/$-(* ?)\n    |-  ^-  ?\n    ?~  a\n      &amp;\n    ?&amp;((b n.a) $(a l.a) $(a r.a))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =b (sa `(list [@t *])`[['a' 1] ['b' [2 3]] ~])\n&gt; (~(all in b) |=(a/* ?@(+.a &amp; |)))\n    %.n\n&gt; =b (sa `(list @t)`['john' 'bonita' 'daniel' 'madeleine' ~])\n&gt; (~(all in b) |=(a/@t (gte a 100)))\n    %.y\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "any in"
+    ],
+    "doc": "<h1><code>+-any:in</code></h1>\n\n<p>Logical OR</p>\n\n<p>Computes the logical OR on every element of <code>a</code> slammed with <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++set</code>.</p>\n\n<p><code>b</code> is a gate that accepts a noun and produces a boolean.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  any                                               ::  logical OR\n    ~/  %any\n    |*  b/$-(* ?)\n    |-  ^-  ?\n    ?~  a\n      |\n    ?|((b n.a) $(a l.a) $(a r.a))\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =b (sa `(list [@t *])`[['a' 1] ['b' [2 3]] ~])\n&gt; (~(any in b) |=(a/* ?@(+.a &amp; |)))\n    %.y\n&gt; =b (sa `(list @t)`['john' 'bonita' 'daniel' 'madeleine' ~])\n&gt; (~(any in b) |=(a/@t (lte a 100)))\n    %.n\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "del in"
+    ],
+    "doc": "<h1><code>+-del:in</code></h1>\n\n<p>Remove noun</p>\n\n<p>Removes <code>b</code> from the <code>++set</code> <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a set.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A set.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  del                                               ::  b without any a\n    ~/  %del\n    |*  b/*\n    |-  ^+  a\n    ?~  a\n      ~\n    ?.  =(b n.a)\n      ?:  (hor b n.a)\n        [n.a $(a l.a) r.a]\n      [n.a l.a $(a r.a)]\n    |-  ^-  {$?($~ _a)}\n    ?~  l.a  r.a\n    ?~  r.a  l.a\n    ?:  (vor n.l.a n.r.a)\n      [n.l.a l.l.a $(l.a r.l.a)]\n    [n.r.a $(r.a l.r.a) r.r.a]\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =b (sa `(list @t)`['a' 'b' 'c' ~])\n&gt; (~(del in b) 'a')\n{'c' 'b'}\n&gt; =b (sa `(list @t)`['john' 'bonita' 'daniel' 'madeleine' ~])\n&gt; (~(del in b) 'john')\n{'bonita' 'madeleine' 'daniel'}\n&gt; (~(del in b) 'susan')\n{'bonita' 'madeleine' 'daniel' 'john'}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "dig in"
+    ],
+    "doc": "<h1><code>+-dig:in</code></h1>\n\n<p>Axis a in b</p>\n\n<p>Produce the axis of <code>b</code> within <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++set</code>.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>The <code>++unit</code> of an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  dig                                               ::  axis of a in b\n    |=  b/*\n    =+  c=1\n    |-  ^-  (unit @)\n    ?~  a  ~\n    ?:  =(b n.a)  [~ u=(peg c 2)]\n    ?:  (hor b n.a)\n      $(a l.a, c (peg c 6))\n    $(a r.a, c (peg c 7))\n  ::\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a (sa `(list @)`[1 2 3 4 5 6 7 ~])\n&gt; a\n{5 4 7 6 1 3 2}\n&gt; -.a\nn=6\n&gt; (~(dig in a) 7)\n[~ 12]\n&gt; (~(dig in a) 2)\n[~ 14]\n&gt; (~(dig in a) 6)\n[~ 2]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "gas in"
+    ],
+    "doc": "<h1><code>+-gas:in</code></h1>\n\n<p>Concatenate</p>\n\n<p>Insert the elements of a <code>++list</code> <code>b</code> into a <code>++set</code> <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a set.</p>\n\n<p><code>b</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++set</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  gas                                               ::  concatenate\n    ~/  %gas\n    |=  b/(list _?&gt;(?=(^ a) n.a))\n    |-  ^+  a\n    ?~  b\n      a\n    $(b t.b, a (put i.b))\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; b\n{'bonita' 'madeleine' 'rudolf' 'john'}\n&gt; (~(gas in b) `(list @t)`['14' 'things' 'number' '1.337' ~])\n{'1.337' '14' 'number' 'things' 'bonita' 'madeleine' 'rudolf' 'john'}\n&gt; (~(gas in s) `(list ,@t)`['1' '2' '3' ~])\n{'1' '3' '2' 'e' 'd' 'a' 'c' 'b'}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "has in"
+    ],
+    "doc": "<h1><code>+-has:in</code></h1>\n\n<p>b in a?</p>\n\n<p>Checks if <code>b</code> is an element of <code>a</code>, producing a boolean.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <a href=\"\"><code>++set</code></a>.</p>\n\n<p><code>b</code> is a <a href=\"\">noun</a>.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  has                                               ::  b exists in a check\n    ~/  %has\n    |*  b/*\n    |-  ^-  ?\n    ?~  a\n      |\n    ?:  =(b n.a)\n      &amp;\n    ?:  (hor b n.a)\n      $(a l.a)\n    $(a r.a)\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a (~(gas in `(set @t)`~) `(list @t)`[`a` `b` `c` ~])\n&gt; (~(has in a) `a`)\n%.y\n&gt; (~(has in a) 'z')\n%.n\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "int in"
+    ],
+    "doc": "<h1><code>+-int:in</code></h1>\n\n<p>Intersection</p>\n\n<p>Produces a set of the intersection between two <code>++set</code>s of the same type,\n<code>a</code> and <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a set.</p>\n\n<p><code>b</code> is a set.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++set</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  int                                               ::  intersection\n    ~/  %int\n    |*  b/_a\n    |-  ^+  a\n    ?~  b\n      ~\n    ?~  a\n      ~\n    ?.  (vor n.a n.b)\n      $(a b, b a)\n    ?:  =(n.b n.a)\n      [n.a $(a l.a, b l.b) $(a r.a, b r.b)]\n    ?:  (hor n.b n.a)\n      %-  uni(a $(a l.a, b [n.b l.b ~]))  $(b r.b)\n    %-  uni(a $(a r.a, b [n.b ~ r.b]))  $(b l.b)\n  ::\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(int in (sa \"ac\")) (sa \"ha\"))\n{~~a}\n&gt; (~(int in (sa \"acmo\")) ~)\n{}\n&gt; (~(int in (sa \"acmo\")) (sa \"ham\"))\n{~~a ~~m}\n&gt; (~(int in (sa \"acmo\")) (sa \"lep\"))\n{}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "put in"
+    ],
+    "doc": "<h1><code>+-put:in</code></h1>\n\n<p>Put b in a</p>\n\n<p>Add an element <code>b</code> to the <code>++set</code> <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a set.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++set</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  put                                               ::  puts b in a, sorted\n    ~/  %put\n    |*  b/*\n    |-  ^+  a\n    ?~  a\n      [b ~ ~]\n    ?:  =(b n.a)\n      a\n    ?:  (hor b n.a)\n      =+  c=$(a l.a)\n      ?&gt;  ?=(^ c)\n      ?:  (vor n.a n.c)\n        [n.a c r.a]\n      [n.c l.c [n.a r.c r.a]]\n    =+  c=$(a r.a)\n    ?&gt;  ?=(^ c)\n    ?:  (vor n.a n.c)\n      [n.a l.a c]\n    [n.c [n.a l.a l.c] r.c]\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; =a (~(gas in `(set @t)`~) `(list @t)`[`a` `b` `c` ~])\n&gt; =b (~(put in a) `d`)\n&gt; b\n{`d` `a` `c` `b`}\n&gt; -.l.+.b\nn=`d`\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rep in"
+    ],
+    "doc": "<h1><code>+-rep:in</code></h1>\n\n<p>Accumulate</p>\n\n<p>Accumulate the elements of <code>a</code> using a gate <code>c</code> and an accumulator <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++set</code>.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<p><code>c</code> is a gate.</p>\n\n<h2>Produces</h2>\n\n<p>A noun.</p>\n\n<h2>Source</h2>\n\n<pre><code>+-  rep                                               ::  replace by product\n  |*  b/_|=({* *} +&lt;+)\n  |-\n  ?~  a  +&lt;+.b\n  $(a r.a, +&lt;+.b $(a l.a, +&lt;+.b (b n.a +&lt;+.b)))\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a (~(gas in *(set @)) [1 2 3 ~])\n&gt; a\n{1 3 2}\n&gt; (~(rep in a) 0 |=([a/@ b/@] (add a b)))\n6\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "run in"
+    ],
+    "doc": "<h1><code>+-run:in</code></h1>\n\n<p>Apply gate to set (often called <em>map</em>)</p>\n\n<p>Produce a <code>++set</code> containing the products of gate <code>b</code> applied to each element\nin <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++set</code>.</p>\n\n<p><code>b</code> is a gate.</p>\n\n<h2>Produces</h2>\n\n<p>A set.</p>\n\n<h2>Source</h2>\n\n<pre><code>+-  run                                               ::  apply gate to values\n    ~/  %run\n    |*  b/gate\n    =|  c/(set _?&gt;(?=(^ a) (b n.a)))\n    |-  ?~  a  c\n    =.  c  (~(put in c) (b n.a))\n    =.  c  $(a l.a, c c)\n    $(a r.a, c c)\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =s (sy ~[\"a\" \"A\" \"b\" \"c\"])\n&gt; s\n{\"A\" \"a\" \"c\" \"b\"}\n&gt; (~(run in s) cuss)\n{'A' 'C' 'B'}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "tap in"
+    ],
+    "doc": "<h1><code>+-tap:in</code></h1>\n\n<p>Set to list</p>\n\n<p>Flattens the <code>++set</code> <code>a</code> into a <code>++list</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an set.</p>\n\n<h2>Produces</h2>\n\n<p>A list.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  tap                                               ::  convert to list\n    ~/  %tap\n    |=  b/(list _?&gt;(?=(^ a) n.a))\n    ^+  b\n    ?~  a\n      b\n    $(a r.a b [n.a $(a l.a)])\n  ::\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =s (sa `(list @t)`['a' 'b' 'c' 'd' 'e' ~])\n&gt; s\n{'e' 'd' 'a' 'c' 'b'}\n&gt; (~(tap in s) `(list @t)`['1' '2' '3' ~])\n~['b' 'c' 'a' 'd' 'e' '1' '2' '3']\n&gt; b\n{'bonita' 'madeleine' 'daniel' 'john'}\n~zod/try=&gt; (~(tap in b) `(list ,@t)`['david' 'people' ~])\n~['john' 'daniel' 'madeleine' 'bonita' 'david' 'people']\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "uni in"
+    ],
+    "doc": "<h1><code>+-uni:in</code></h1>\n\n<p>Union</p>\n\n<p>Produces a set of the union between two <a href=\"\"><code>++set</code></a>s of the same type, <code>a</code> and\n<code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a set.</p>\n\n<p><code>b</code> is a set.</p>\n\n<h2>Produces</h2>\n\n<p>A set.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  uni                                               ::  union\n    ~/  %uni\n    |*  b/_a\n    ?:  =(a b)  a\n    |-  ^+  a\n    ?~  b\n      a\n    ?~  a\n      b\n    ?:  (vor n.a n.b)\n      ?:  =(n.b n.a)\n        [n.b $(a l.a, b l.b) $(a r.a, b r.b)]\n      ?:  (hor n.b n.a)\n        $(a [n.a $(a l.a, b [n.b l.b ~]) r.a], b r.b)\n      $(a [n.a l.a $(a r.a, b [n.b ~ r.b])], b l.b)\n    ?:  =(n.a n.b)\n      [n.b $(b l.b, a l.a) $(b r.b, a r.a)]\n    ?:  (hor n.a n.b)\n      $(b [n.b $(b l.b, a [n.a l.a ~]) r.b], a r.a)\n    $(b [n.b l.b $(b r.b, a [n.a ~ r.a])], a l.a)\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(uni in (sa \"ac\")) (sa \"ha\"))\n{~~a ~~c ~~h}\n &gt; (~(uni in (sa \"acmo\")) ~)\n{~~a ~~c ~~m ~~o}\n&gt; (~(uni in (sa \"acmo\")) (sa \"ham\"))\n{~~a ~~c ~~m ~~o ~~h}\n&gt; (~(uni in (sa \"acmo\")) (sa \"lep\"))\n{~~e ~~a ~~c ~~m ~~l ~~o ~~p}\n</code></pre>\n\n<hr/>"
+  },
+
+  {
+    "keys": [
+      "by"
+    ],
+    "doc": "<h1><code>++by</code></h1>\n\n<p>Map operations</p>\n\n<pre><code>++  by                                                  ::  map engine\n  ~/  %by\n  |_  a/(map)\n</code></pre>\n\n\n<p>Container arm for map operation arms. A map is a set of key, value\npairs. The contained arms inherit it's sample map, <code>a</code>.</p>\n\n<p><code>a</code> is a map.</p>\n\n<pre><code>&gt; ~(. by (mo (limo [%a 1] [%b 2] ~)))\n&lt;19.irb [nlr([p={%a %b} q=@ud]) &lt;414.rvm 101.jzo 1.ypj %164&gt;]&gt;\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "all by"
+    ],
+    "doc": "<h1><code>+-all:by</code></h1>\n\n<p>Logical AND</p>\n\n<pre><code>  +-  all                                               ::  logical AND\n    ~/  %all\n    |*  b/$-(* ?)\n    |-  ^-  ?\n    ?~  a\n      &amp;\n    ?&amp;((b q.n.a) $(a l.a) $(a r.a))\n  ::\n</code></pre>\n\n\n<p>Computes the logical AND on the results of slamming every element in map\n<code>a</code> with gate <code>b</code>. Produces a loobean.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a wet gate.</p>\n\n<pre><code>&gt; =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])\n&gt; (~(all by b) |=(a/* ?@(a &amp; |)))\n%.n\n&gt; =a (mo `(list {@t @u})`[['a' 1] ['b' 2] ['c' 3] ['d' 4] ['e' 5] ~])\n&gt; (~(all by a) |=(a/@ (lte a 6)))\n%.y\n&gt; (~(all by a) |=(a/@ (lte a 4)))\n%.n\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "any by"
+    ],
+    "doc": "<h1><code>+-any:by</code></h1>\n\n<p>Logical OR</p>\n\n<pre><code>  +-  any                                               ::  logical OR\n    ~/  %any\n    |*  b=$+(* ?)\n    |-  ^-  ?\n    ?~  a\n      |\n    ?|((b q.n.a) $(a l.a) $(a r.a))\n</code></pre>\n\n<p>Computes the logical OR on the results of slamming every element with\ngate <code>b</code>. Produces a loobean.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a wet gate.</p>\n\n<pre><code>&gt; =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])\n&gt; (~(all by b) |=(a/* ?@(a &amp; |)))\n%.y\n&gt; =a (mo `(list {@t @u})`[['a' 1] ['b' 2] ['c' 3] ['d' 4] ['e' 5] ~])\n&gt; (~(any by a) |=(a=@ (lte a 4)))\n%.y\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "del by"
+    ],
+    "doc": "<h1><code>+-del:by</code></h1>\n\n<p>Delete</p>\n\n<pre><code>  +-  del                                               ::  delete at key b\n    ~/  %del\n    |*  b/*\n    |-  ^+  a\n    ?~  a\n      ~\n    ?.  =(b p.n.a)\n      ?:  (gor b p.n.a)\n        [n.a $(a l.a) r.a]\n      [n.a l.a $(a r.a)]\n    |-  ^-  {$?($~ _a)}\n    ?~  l.a  r.a\n    ?~  r.a  l.a\n    ?:  (vor p.n.l.a p.n.r.a)\n      [n.l.a l.l.a $(l.a r.l.a)]\n    [n.r.a $(r.a l.r.a) r.r.a]\n  ::\n</code></pre>\n\n<p>Produces map <code>a</code> with the element located at key <code>b</code> removed.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a key as a noun.</p>\n\n<pre><code>    &gt; =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])\n    &gt; (~(del by b) `a`)\n    {[p=`b` q=[2 3]]}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "dig by"
+    ],
+    "doc": "<h1><code>+-dig:by</code></h1>\n\n<p>Axis of key</p>\n\n<pre><code>  +-  dig                                               ::  axis of b key\n    |=  b/*\n    =+  c=1\n    |-  ^-  (unit @)\n    ?~  a  ~\n    ?:  =(b p.n.a)  [~ u=(peg c 2)]\n    ?:  (gor b p.n.a)\n      $(a l.a, c (peg c 6))\n    $(a r.a, c (peg c 7))\n  ::\n</code></pre>\n\n\n<p>Produce the axis of key <code>b</code> within map <code>a</code>.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a key as a noun.</p>\n\n<pre><code>    &gt; =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])  \n    &gt; (~(dig by b) `b`)\n    [~ 2]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "gas by"
+    ],
+    "doc": "<h1><code>+-gas:by</code></h1>\n\n<p>Concatenate</p>\n\n<pre><code>  +-  gas                                               ::  concatenate\n    ~/  %gas\n    |=  b/(list _?&gt;(?=(^ a) n.a))\n    |-  ^+  a\n    ?~  b\n      a\n    $(b t.b, a (put i.b))\n  ::\n</code></pre>\n\n\n<p>Insert a list of key-value pairs <code>b</code> into map <code>a</code>.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a list of cells of key-value nouns <code>p</code> and <code>q</code>.</p>\n\n<pre><code>&gt; =a (mo `(list {@t *})`[[`a` 1] [`b` 2] ~])\n&gt; =b `(list {@t *})`[[`c` 3] [`d` 4] ~]\n&gt; (~(gas by a) b)\n{[p=`d` q=4] [p=`a` q=1] [p=`c` q=3] [p=`b` q=2]}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "get by"
+    ],
+    "doc": "<h1><code>+-get:by</code></h1>\n\n<p>Grab unit value</p>\n\n<pre><code>  +-  get                                               ::  unit value by key\n    ~/  %get\n    |*  b=*\n    |-  ^-  ?(~ [~ u=_?&gt;(?=(^ a) q.n.a)])\n    ?~  a\n      ~\n    ?:  =(b p.n.a)\n      [~ u=q.n.a]\n    ?:  (gor b p.n.a)\n      $(a l.a)\n    $(a r.a)\n</code></pre>\n\n<p>Produce the unit value of the value located at key <code>b</code> within map <code>a</code>.</p>\n\n<p><code>a</code> is a map</p>\n\n<p><code>b</code> is a key as a noun</p>\n\n<pre><code>    &gt; =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])  \n    &gt; (~(get by b) `b`)\n    [~ [2 3]]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "got by"
+    ],
+    "doc": "<h1><code>+-got:by</code></h1>\n\n<p>Assert</p>\n\n<pre><code>  +-  got\n    |*  b/*\n    (need (get b))\n</code></pre>\n\n<p>Produce the value located at key <code>b</code> within map <code>a</code>. Crash if key <code>b</code>\ndoes not exist.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a key.</p>\n\n<pre><code>    &gt; =m (mo `(list {@t *})`[['a' 1] ['b' 2] ~])\n    &gt; m\n    {[p='a' q=1] [p='b' q=2]}\n    &gt; (~(get by m) 'a')\n    [~ 1]\n    &gt; (~(got by m) 'a')\n    1\n    &gt; (~(got by m) 'c')\n    ! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "has by"
+    ],
+    "doc": "<h1><code>+-has:by</code></h1>\n\n<p>Key existence check</p>\n\n<pre><code>  +-  has                                               ::  key existence check\n    ~/  %has\n    |*  b/*\n    !=(~ (get b))\n</code></pre>\n\n\n<p>Checks whether map <code>a</code> contains an element with key <code>b</code>, producing a\nloobean.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a key as a noun.</p>\n\n<pre><code>    &gt; =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])  \n    &gt; (~(has by b) `b`)\n    %.y\n    &gt; (~(has by b) `c`)\n    %.n\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "int by"
+    ],
+    "doc": "<h1><code>+-int:by</code></h1>\n\n<p>Intersection</p>\n\n<pre><code>  +-  int                                               ::  intersection\n    ~/  %int\n    |*  b/_a\n    |-  ^+  a\n    ?~  b\n      ~\n    ?~  a\n      ~\n    ?:  (vor p.n.a p.n.b)\n      ?:  =(p.n.b p.n.a)\n        [n.b $(a l.a, b l.b) $(a r.a, b r.b)]\n      ?:  (gor p.n.b p.n.a)\n        %-  uni(a $(a l.a, b [n.b l.b ~]))  $(b r.b)\n      %-  uni(a $(a r.a, b [n.b ~ r.b]))  $(b l.b)\n    ?:  =(p.n.a p.n.b)\n      [n.b $(b l.b, a l.a) $(b r.b, a r.a)]\n    ?:  (gor p.n.a p.n.b)\n      %-  uni(a $(b l.b, a [n.a l.a ~]))  $(a r.a)\n    %-  uni(a $(b r.b, a [n.a ~ r.a]))  $(a l.a)\n  ::\n</code></pre>\n\n<p>Produces a map of the (key) intersection between two maps of the same\ntype, <code>a</code> and <code>b</code>. If both maps have an identical key that point to\ndifferent values, the element from map <code>b</code> is used.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a map.</p>\n\n<pre><code>    &gt; =n (mo `(list {@t *})`[['a' 1] ['c' 3] ~])\n    &gt; n\n    {[p='a' q=1] [p='c' q=3]}\n    &gt; m\n    {[p='a' q=1] [p='b' q=2]}\n    &gt; (~(int by m) n)\n    {[p='a' q=1]}\n    ~ravpel-holber/try=&gt; =p (mo `(list {@t *})`[['a' 2] ['b' 2] ~])\n    &gt; p\n    {[p='a' q=2] [p='b' q=2]}\n    &gt; (~(int by p) n)\n    {[p='a' q=2]}\n    &gt; =q (mo `(list {@t *})`[['a' 2] ['c' 2] ~])\n    &gt; q\n    {[p='a' q=2] [p='b' q=2]}\n    &gt; (~(int by p) q)\n    {[p='a' q=2] [p='b' q=2]}\n    &gt; =o (mo `(list {@t *})`[['c' 3] ['d' 4] ~])\n    &gt; (~(int by m) o)\n    {}\n</code></pre>\n\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "mar by"
+    ],
+    "doc": "<h1><code>+-mar:by</code></h1>\n\n<p>Assert and Add</p>\n\n<pre><code>  +-  mar                                               ::  add with validation\n    |*  [b=_?&gt;(?=(^ a) p.n.a) c=(unit ,_?&gt;(?=(^ a) q.n.a))]\n    ?~  c\n      (del b)\n    (put b u.c)\n</code></pre>\n\n<p>Produces map <code>a</code> with the addition of a key-value pair, where the value\nis a nonempty unit.</p>\n\n<p>Accept a noun and a unit of a noun of the type of the map's keys and\nvalues, respectively. Validate that the value is not null and put the\npair in the map. If the value is null, delete the key.</p>\n\n<p>XX This arm is broken, asana task 15186618346453</p>\n\n<pre><code>    &gt; m\n    {[p='a' q=1] [p='b' q=2]}\n    &gt; (~(mar by m) 'c' (some 3))\n    ! -find-limb.n\n    ! find-none\n    ! exit\n    &gt; (~(mar by m) 'c' ~)\n    ! -find-limb.n\n    ! find-none\n    ! exit\n    &gt; (~(mar by m) 'b' ~)\n    ! -find-limb.n\n    ! find-none\n    ! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "put by"
+    ],
+    "doc": "<h1><code>+-put:by</code></h1>\n\n<p>Add key-value pair</p>\n\n<pre><code>  +-  put                                               ::  adds key-value pair\n    ~/  %put\n    |*  {b/* c/*}\n    |-  ^+  a\n    ?~  a\n      [[b c] ~ ~]\n    ?:  =(b p.n.a)\n      ?:  =(c q.n.a)\n        a\n      [[b c] l.a r.a]\n    ?:  (gor b p.n.a)\n      =+  d=$(a l.a)\n      ?&gt;  ?=(^ d)\n      ?:  (vor p.n.a p.n.d)\n        [n.a d r.a]\n      [n.d l.d [n.a r.d r.a]]\n    =+  d=$(a r.a)\n    ?&gt;  ?=(^ d)\n    ?:  (vor p.n.a p.n.d)\n      [n.a l.a d]\n    [n.d [n.a l.a l.d] r.d]\n  ::\n</code></pre>\n\n<p>Produces <code>a</code> with the addition of the key-value pair of <code>b</code> and <code>c</code>.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a key of the same type as the keys in <code>a</code>.</p>\n\n<p><code>c</code> is a value of the same type of the values in <code>a</code>.</p>\n\n<pre><code>&gt; m\n{[p='a' q=1] [p='b' q=2]}\n&gt; (~(put by m) 'c' 3)\n{[p='a' q=1] [p='c' q=3] [p='b' q=2]}\n&gt; (~(put by m) \"zod\" 26)\n! type-fail\n! exit\n&gt; (~(put by m) 'a' 2)\n{[p='a' q=2] [p='b' q=2]}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rep by"
+    ],
+    "doc": "<h1><code>+-rep:by</code></h1>\n\n<pre><code>  +-  rep                                               ::  replace by product\n    |*  b/_|=({* *} +&lt;+)\n    |-\n    ?~  a  +&lt;+.b\n    $(a r.a, +&lt;+.b $(a l.a, +&lt;+.b (b n.a +&lt;+.b)))\n  ::\n</code></pre>\n\n<p>Accumulate using gate from values in map</p>\n\n<p>XX interface changing.</p>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rib by"
+    ],
+    "doc": "<h1><code>+-rib:by</code></h1>\n\n<pre><code>  +-  rib                                               ::  transform + product\n    |*  {b/* c/$-(* *)}\n    |-  ^+  [b a]\n    ?~  a  [b ~]\n    =+  d=(c n.a b)\n    =.  n.a  +.d\n    =+  e=$(a l.a, b -.d)\n    =+  f=$(a r.a, b -.e)\n    [-.f [n.a +.e +.f]]\n  ::\n</code></pre>\n\n<p>Replace values with accumulator</p>\n\n<p>XX interface changing, possibly disappearing</p>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "run by"
+    ],
+    "doc": "<h1><code>+-run:by</code></h1>\n\n<p>Transform values</p>\n\n<pre><code>  +-  run                                               ::  apply gate to values\n    |*  b/$-(* *)\n    |-\n    ?~  a  a\n    [n=[p=p.n.a q=(b q.n.a)] l=$(a l.a) r=$(a r.a)]\n</code></pre>\n\n<p>Iterates over every value in set <code>a</code> using gate <code>b</code>. Produces a map.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a wet gate.</p>\n\n<pre><code>&gt; m\n{[p='a' q=1] [p='b' q=2]}\n&gt; ^+(m (~(run by m) dec))\n{[p='a' q=0] [p='b' q=1]}\n&gt; `(map @tas @t)`(~(run by m) (cury scot %ux))\n{[p=%a q='0x1'] [p=%b q='0x2']}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "tap by"
+    ],
+    "doc": "<h1><code>+-tap:by</code></h1>\n\n<p>Listify pairs</p>\n\n<pre><code>  +-  tap                                               ::  listify pairs\n    ~/  %tap\n    |=  b/(list _?&gt;(?=(^ a) n.a))\n    ^+  b\n    ?~  a\n      b\n    $(a r.a, b [n.a $(a l.a)])\n  ::\n</code></pre>\n\n<p>Produces the list of all elements in map <code>a</code> that is prepended to list\n<code>b</code>, which is empty by default.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a list.</p>\n\n<pre><code>{[p='a' q=1] [p='b' q=2]}\n&gt; `*`m\n[[98 2] [[97 1] 0 0] 0]\n&gt; (~(tap by m))\n~[[p='b' q=2] [p='a' q=1]]\n&gt; `*`(~(tap by m))\n[[98 2] [97 1] 0]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "uni by"
+    ],
+    "doc": "<h1><code>+-uni:by</code></h1>\n\n<p>Union</p>\n\n<pre><code>  +-  uni                                               ::  union, merge\n    ~/  %uni\n    |*  b/_a\n    |-  ^+  a\n    ?~  b\n      a\n    ?~  a\n      b\n    ?:  (vor p.n.a p.n.b)\n      ?:  =(p.n.b p.n.a)\n        [n.b $(a l.a, b l.b) $(a r.a, b r.b)]\n      ?:  (gor p.n.b p.n.a)\n        $(a [n.a $(a l.a, b [n.b l.b ~]) r.a], b r.b)\n      $(a [n.a l.a $(a r.a, b [n.b ~ r.b])], b l.b)\n    ?:  =(p.n.a p.n.b)\n      [n.b $(b l.b, a l.a) $(b r.b, a r.a)]\n    ?:  (gor p.n.a p.n.b)\n      $(b [n.b $(b l.b, a [n.a l.a ~]) r.b], a r.a)\n    $(b [n.b l.b $(b r.b, a [n.a ~ r.a])], a l.a)\n</code></pre>\n\n<p>Produces a map of the union between the keys of <code>a</code> and <code>b</code>. If <code>b</code>\nshares a key with <code>a</code>, the tuple from <code>a</code> is preserved.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a map.</p>\n\n<pre><code>&gt; m\n{[p='a' q=1] [p='b' q=2]}\n&gt; o\n{[p='d' q=4] [p='c' q=3]}\n&gt; (~(uni by m) o)\n{[p='d' q=4] [p='a' q=1] [p='c' q=3] [p='b' q=2]}\n&gt; (~(uni by m) ~)\n{[p='a' q=1] [p='b' q=2]}\n&gt; n\n{[p='a' q=1] [p='c' q=9]}\n&gt; (~(uni by o) n)\n{[p='d' q=4] [p='a' q=1] [p='c' q=3]}\n&gt; =n (mo `(list ,[@t *])`[['a' 1] ['c' 9] ~])\n&gt; n\n{[p='a' q=1] [p='c' q=9]}\n&gt; (~(uni by o) n)\n{[p='d' q=4] [p='a' q=1] [p='c' q=9]}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "urn by"
+    ],
+    "doc": "<h1><code>+-urn:by</code></h1>\n\n<p>Turn (with key)</p>\n\n<pre><code>  +-  urn                                               ::  apply gate to nodes\n    |*  b/$-({* *} *)\n    |-\n    ?~  a  ~\n    [n=[p=p.n.a q=(b p.n.a q.n.a)] l=$(a l.a) r=$(a r.a)]\n</code></pre>\n\n<p>Iterates over every value in map <code>a</code> using gate <code>b</code>, which accepts both\nthe key and the value of each element as its sample.</p>\n\n<p><code>a</code> is a map.</p>\n\n<p><code>b</code> is a wet gate that accepts two nouns (a key and a value) and\nproduces a noun (the new value).</p>\n\n<pre><code>&gt; m\n{[p='a' q=1] [p='b' q=2]}\n&gt; (~(urn by m) |=(a=[p=* q=*] q.a))\n{[p='a' q=1] [p='b' q=2]}\n&gt; (~(urn by m) |=(a=[p=* q=*] 7))\n{[p='a' q=7] [p='b' q=7]}\n&gt; (~(urn by m) |=(a=[p=* q=*] p.a))\n{[p='a' q=97] [p='b' q=98]}\n</code></pre>\n\n<hr/>"
+  },
+
+  {
+    "keys": [
+      "ja"
+    ],
+    "doc": "<h1><code>++ja</code></h1>\n\n<p>Jar engine</p>\n\n<pre><code>  |_  a/(jar)\n</code></pre>\n\n<p>A container arm for <code>++jar</code> operation arms. A <code>++jar</code> is a <code>++map</code> of\n<code>++list</code>s. The contained arms inherit the sample jar.</p>\n\n<p><code>a</code> is a jar.</p>\n\n<pre><code>&gt; ~(. ja (mo (limo a/\"ho\" b/\"he\" ~)))\n&lt;2.dgz [nlr([p={%a %b} q=\"\"]) &lt;414.fvk 101.jzo 1.ypj %164&gt;]&gt;\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "get ja"
+    ],
+    "doc": "<h1><code>+-get:ja</code></h1>\n\n<p>Grab value by key</p>\n\n<pre><code>  +-  get                                               ::  gets list by key\n    |*  b/*\n    =+  c=(~(get by a) b)\n    ?~(c ~ u.c)\n  ::\n</code></pre>\n\n<p>Produces a list retrieved from jar <code>a</code> using the key <code>b</code>.</p>\n\n<p><code>a</code> is a <code>++jar</code>.</p>\n\n<p><code>b</code> is a key of the same type as the keys in <code>a</code>.</p>\n\n<pre><code>&gt; =l (mo `(list ,[@t (list ,@)])`[['a' `(list ,@)`[1 2 3 ~]] ['b' `(list ,@)`[4 5 6 ~]] ~])\n&gt; l\n{[p='a' q=~[1 2 3]] [p='b' q=~[4 5 6]]}\n&gt; (~(get ja l) 'a')\n~[1 2 3]\n&gt; (~(get ja l) 'b')\n~[4 5 6]\n&gt; (~(get ja l) 'c')\n~\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "add ja"
+    ],
+    "doc": "<h1><code>+-add:ja</code></h1>\n\n<p>Prepend to list</p>\n\n<pre><code>  +-  add                                               ::  adds key-list pair\n    |*  {b/* c/*}\n    =+  d=(get b)\n    (~(put by a) b [c d])\n</code></pre>\n\n<p>Produces jar <code>a</code> with value <code>c</code> prepended to the list located at key\n<code>b</code>.</p>\n\n<p><code>a</code> is a jar.</p>\n\n<p><code>b</code> is a key of the same type as the keys in <code>a</code>.</p>\n\n<p><code>c</code> is a value of the same type as the values in <code>a</code>.</p>\n\n<pre><code>&gt; =l (mo `(list ,[@t (list ,@)])`[['a' `(list ,@)`[1 2 3 ~]] ['b' `(list ,@)`[4 5 6 ~]] ~])\n&gt; l\n{[p='a' q=~[1 2 3]] [p='b' q=~[4 5 6]]}\n&gt; (~(add ja l) 'b' 7)\n{[p='a' q=~[1 2 3]] [p='b' q=~[7 4 5 6]]}\n&gt; (~(add ja l) 'a' 100)\n{[p='a' q=~[100 1 2 3]] [p='b' q=~[4 5 6]]}\n&gt; (~(add ja l) 'c' 7)\n{[p='a' q=~[1 2 3]] [p='c' q=~[7]] [p='b' q=~[4 5 6]]}\n&gt; (~(add ja l) 'c' `(list ,@)`[7 8 9 ~])\n! type-fail\n! exit\n</code></pre>\n\n<p>**</p>"
+  },
+  {
+    "keys": [
+      "ju"
+    ],
+    "doc": "<h1><code>++ju</code></h1>\n\n<p>Jug operations</p>\n\n<pre><code>++  ju                                                  ::  jug engine\n  |/  a/(jug)\n</code></pre>\n\n<p>Container arm for jug operation arms. A <code>++jug</code> is a <code>++map</code> of\n<code>++sets</code>. The contained arms inherit its sample jug, <code>a</code>.</p>\n\n<p><code>a</code> is a jug.</p>\n\n<pre><code>&gt; ~(. ju (mo (limo a/(sa \"ho\") b/(sa \"he\") ~)))\n&lt;2.dgz [nlr([p={%a %b} q={nlr(^$1{@tD $1}) nlr(^$3{@tD $3})}]) &lt;414.fvk 101.jzo 1.ypj %164&gt;]&gt;\n</code></pre>"
+  },
+  {
+    "keys": [
+      "del ju"
+    ],
+    "doc": "<h1><code>+-del:ju</code></h1>\n\n<p>Remove</p>\n\n<pre><code>  +-  del                                               ::  del key-set pair\n    |*  {b/* c/*}\n    ^+  a\n    =+  d=(get b)\n    =+  e=(~(del in d) c)\n    ?~  e\n      (~(del by a) b)\n    (~(put by a) b e)\n  ::\n</code></pre>\n\n\n<p>Produces jug <code>a</code> with value <code>c</code> removed from set located at key <code>b</code>.</p>\n\n<p><code>a</code> is a jug.</p>\n\n<p><code>b</code> is a key of the same type as the keys in <code>a</code>.</p>\n\n<p><code>c</code> is the value of the same type of the keys in <code>a</code> that is to be\nremoved.</p>\n\n<pre><code>&gt; s\n{[p='a' q={1 3 2}] [p='b' q={5 4 6}]}\n&gt; (~(del ju s) 'a' 1)\n{[p='a' q={3 2}] [p='b' q={5 4 6}]}\n&gt; (~(del ju s) 'c' 7)\n{[p='a' q={1 3 2}] [p='b' q={5 4 6}]}        \n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "get ju"
+    ],
+    "doc": "<h1><code>+-get:ju</code></h1>\n\n<p>Retrieve set</p>\n\n<pre><code>  +-  get                                               ::  gets set by key\n    |*  b/*\n    =+  c=(~(get by a) b)\n    ?~(c ~ u.c)\n  ::\n</code></pre>\n\n<p>Produces a set retrieved from jar <code>a</code> using key <code>b</code>.</p>\n\n<p><code>a</code> is a jar.</p>\n\n<p><code>b</code> is a key of the same type as the keys in <code>a</code>.</p>\n\n<pre><code>&gt; s\n{[p='a' q={1 3 2}] [p='b' q={5 4 6}]}\n&gt; (~(get ju s) 'a')\n{1 3 2}\n&gt; (~(get ju s) 'b')\n{5 4 6}\n&gt; (~(get ju s) 'c')\n~\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "has ju"
+    ],
+    "doc": "<h1><code>+-has:ju</code></h1>\n\n<p>Check contents</p>\n\n<pre><code>  +-  has                                               ::  existence check\n    |*  {b/* c/*}\n    ^-  ?\n    (~(has in (get b)) c)\n  ::\n</code></pre>\n\n\n<p>Computes whether a value <code>c</code> exists within the set located at key <code>b</code>\nwith jar <code>a</code>. Produces a loobean.</p>\n\n<p><code>a</code> is a set.</p>\n\n<p><code>b</code> is a key as a noun.</p>\n\n<p><code>c</code> is a value as a noun.</p>\n\n<pre><code>&gt; s\n{[p='a' q={1 3 2}] [p='b' q={5 4 6}]}\n&gt; (~(has ju s) 'a' 3)\n%.y\n&gt; (~(has ju s) 'b' 6)\n%.y\n&gt; (~(has ju s) 'a' 7)\n%.n\n&gt; (~(has jus s) 'c' 7)\n! -find-limb.jus\n! find-none\n! exit\n&gt; (~(has ju s) 'c' 7)\n%.n\n</code></pre>\n\n<hr/>"
+  },
+
+  {
+    "keys": [
+      "to"
+    ],
+    "doc": "<h1><code>++to</code></h1>\n\n<p>Queue operations</p>\n\n<p>Container arm for queue operation arms. The contained arms inherit its\nsample <code>++qeu</code> <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a queue, ++qeu.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  to                                                  ::  queue engine\n  |/  a/(qeu)\n</code></pre>"
+  },
+  {
+    "keys": [
+      "bal to"
+    ],
+    "doc": "<h1><code>+-bal:to</code></h1>\n\n<p>Balance</p>\n\n<p>Vertically rebalances queue <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a queue.</p>\n\n<h2>Produces</h2>\n\n<p>A queue.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  bal\n    |-  ^+  a\n    ?~  a  ~\n    ?.  |(?=($~ l.a) (vor n.a n.l.a))\n      $(a [n.l.a l.l.a $(a [n.a r.l.a r.a])])\n    ?.  |(?=($~ r.a) (vor n.a n.r.a))\n      $(a [n.r.a $(a [n.a l.a l.r.a]) r.r.a])\n    a\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `(qeu tape)`[\"a\" ~ \"b\" ~ \"c\" ~ \"d\" ~ \"e\" ~ \"f\" ~ \"g\" ~ ~]\n{\"a\" \"b\" \"c\" \"d\" \"e\" \"f\" \"g\"}\n&gt; `*`[\"a\" ~ \"b\" ~ \"c\" ~ \"d\" ~ \"e\" ~ \"f\" ~ \"g\" ~ ~]\n[[97 0] 0 [98 0] 0 [99 0] 0 [100 0] 0 [101 0] 0 [102 0] 0 [103 0] 0 0]\n&gt; ~(bal to `(qeu tape)`[\"a\" ~ \"b\" ~ \"c\" ~ \"d\" ~ \"e\" ~ \"f\" ~ \"g\" ~ ~])\n{\"a\" \"b\" \"c\" \"d\" \"e\" \"f\" \"g\"}\n&gt; `*`~(bal to `(qeu tape)`[\"a\" ~ \"b\" ~ \"c\" ~ \"d\" ~ \"e\" ~ \"f\" ~ \"g\" ~ ~])\n[[100 0] [[99 0] [[98 0] [[97 0] 0 0] 0] 0] [101 0] 0 [102 0] 0 [103 0] 0 0]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "dep to"
+    ],
+    "doc": "<h1><code>+-dep:to</code></h1>\n\n<p>Maximum Depth</p>\n\n<p>Produces the maximum depth of leaves (r.a and l.a) in queue <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a queue.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  dep                                               ::  max depth of queue\n    |-  ^-  @\n    ?~  a  0\n    +((max $(a l.a) $(a r.a)))\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a (~(gas to `(qeu @)`~) `(list @)`[1 2 3 4 5 6 7 ~])\n&gt; ~(dep to a)\n4\n&gt; =a (~(gas to `(qeu @)`~) `(list @)`[1 2 3 4 ~])\n&gt; ~(dep to a)\n3\n&gt; =a (~(gas to `(qeu @)`~) `(list @)`[1 2 ~])\n&gt; ~(dep to a)\n2\n&gt; ~(dep to `(qeu tape)`[\"a\" ~ \"b\" ~ \"c\" ~ \"d\" ~ \"e\" ~ \"f\" ~ \"g\" ~ ~])\n7\n&gt; ~(dep to ~(bal to `(qeu tape)`[\"a\" ~ \"b\" ~ \"c\" ~ \"d\" ~ \"e\" ~ \"f\" ~ \"g\" ~ ~]))\n4\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "gas"
+    ],
+    "doc": "<h1><code>+-gas</code></h1>\n\n<p>Push list</p>\n\n<p>Push all elements of <code>++list</code> <code>b</code> into the <code>++queue</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a queue.</p>\n\n<p><code>b</code> is a list.</p>\n\n<h2>Produces</h2>\n\n<p>A queue.</p>\n\n<h2>Source</h2>\n\n<pre><code>+-  gas                                               ::  insert list to queue\n  |=  b=(list ,_?&gt;(?=(^ a) n.a))\n  |-  ^+  a\n  ?~(b a $(b t.b, a (put(+&lt; a) i.b)))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(gas to `(qeu ,@)`~) `(list ,@)`[1 2 3 ~])\n{3 2 1}\n&gt; =a (~(gas to `(qeu ,@)`~) `(list ,@)`[1 2 3 ~])\n&gt; =b `(list ,@)`[4 5 6 ~]\n&gt; (~(gas to a) b)\n{6 5 4 3 2 1}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "get to"
+    ],
+    "doc": "<h1><code>+-get:to</code></h1>\n\n<p>Pop</p>\n\n<p>Produces the head and tail <code>++queue</code> of <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a queue.</p>\n\n<h2>Produces</h2>\n\n<p>The last element in <code>a</code> along with the rest of queue <code>a</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  get                                               ::  head-tail pair\n    |-  ^+  ?&gt;(?=(^ a) [p=n.a q=*(qeu _n.a)])\n    ?~  a\n      !!\n    ?~  r.a\n      [n.a l.a]\n    =+  b=$(a r.a)\n    :-  p.b\n    ?:  |(?=($~ q.b) (vor n.a n.q.b))\n      [n.a l.a q.b]\n    [n.q.b [n.a l.a l.q.b] r.q.b]\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =s (~(gas to *(qeu @)) `(list @)`~[1 2 3])\n&gt; ~(get to s)\n[p=1 q={3 2}]\n&gt; ~(get to ~)\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "nap to"
+    ],
+    "doc": "<h1><code>+-nap:to</code></h1>\n\n<p>Remove last element </p>\n\n<p>Removes the head of <code>++queue</code> <code>a</code>, producing the resulting queue.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a queue.</p>\n\n<h2>Produces</h2>\n\n<p>A queue.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  nap                                               ::  removes head\n    ?&gt;  ?=(^ a)\n    ?:  =(~ l.a)  r.a\n    =+  b=get(a l.a)\n    bal(a ^+(a [p.b q.b r.a]))\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a (~(gas to `(qeu @)`~) `(list @)`[1 2 3 4 5 6 ~])\n&gt; -.a\nn=6\n&gt; =b ~(nap to a)\n&gt; -.b\nn=2\n&gt; b\n{5 4 3 2 1}\n&gt; a\n{6 5 4 3 2 1}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "put to"
+    ],
+    "doc": "<h1><code>+-put:to</code></h1>\n\n<p>Insert</p>\n\n<p>Accept any noun <code>b</code> and adds to <code>++queue</code> <code>a</code> as the head, producing the\nresulting queue.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a queue.</p>\n\n<p><code>b</code> is any noun.</p>\n\n<h2>Produces</h2>\n\n<p>A queue.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  put                                               ::  insert new tail\n    |*  b/*\n    |-  ^+  a\n    ?~  a\n      [b ~ ~]\n    bal(a a(l $(a l.a)))\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(gas to `(qeu @)`~) `(list @)`[3 1 2 4 5 6 ~])\n&gt; (~(put to a) 7)\n{7 6 5 4 2 1 3}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "tap to"
+    ],
+    "doc": "<h1><code>+-tap:to</code></h1>\n\n<p>Queue to list</p>\n\n<p>Produces <code>++queue</code> <code>a</code> as a <code>++list</code> from front to back.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a queue.</p>\n\n<h2>Source</h2>\n\n<pre><code>  +-  tap                                               ::  adds list to end\n    |=  b/(list _?&gt;(?=(^ a) n.a))\n    =+  z=0                                             ::  XX breaks jet match\n    ^+  b\n    ?~  a\n      b\n    $(a r.a, b [n.a $(a l.a)])\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =a (~(gas to `(qeu @)`~) `(list @)`[3 1 2 4 5 6 ~])\n&gt; `*`a\n[6 0 2 [4 [5 0 0] 0] 1 0 3 0 0]\n&gt; (~(tap to a) `(list @)`[99 100 101 ~])\n~[3 1 2 4 5 6 99 100 101]\n</code></pre>\n\n<hr/>"
+  },
+
+  {
+    "keys": [
+      "cork"
+    ],
+    "doc": "<h1><code>++cork</code></h1>\n\n<p>Build <code>f</code> such that <code>(f x) .= (b (a x))</code>.</p>\n\n<p><code>a</code> is a noun.</p>\n\n<p><code>b</code> is a gate.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cork  |*({a/_|=(* **) b/gate} (corl b a))           ::  compose forward\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (:(cork dec dec dec) 20)\n17\n&gt; =mal (mo (limo a+15 b+23 ~))\n&gt; ((cork ~(got by mal) dec) %a)\n14\n&gt; ((cork ~(got by mal) dec) %b)\n22\n</code></pre>"
+  },
+  {
+    "keys": [
+      "corl"
+    ],
+    "doc": "<h1><code>++corl</code></h1>\n\n<p>Gate compose</p>\n\n<p>XX Revisit</p>\n\n<p><code>a</code> is a gate.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  corl                                                ::  compose backwards\n  |*  {a/gate b/_|=(* **)}\n  =&lt;  +:|.((a (b)))      ::  span check\n  |*  c/_+&lt;.b\n  (a (b c))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((corl (lift bex) (slat %ud)) '2')\n[~ 4]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "curr"
+    ],
+    "doc": "<h1><code>++curr</code></h1>\n\n<p>Right curry</p>\n\n<p>Right curry a gate, binding the tail of its sample</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a gate.</p>\n\n<p><code>c</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n\n<h2>Source</h2>\n\n<pre><code>++  curr                                                ::  curry right\n  |*  {a/_|=(^ **) c/*}     \n  |*  b/_+&lt;+.a\n  (a b c)\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =tep (curr scan sym)\n&gt; `@t`(tep \"asd\")\n'asd'\n&gt; `@t`(tep \"lek-om\")\n'lek-om'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cury"
+    ],
+    "doc": "<h1><code>++cury</code></h1>\n\n<p>Curry a gate, binding the head of its sample</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a gate.</p>\n\n<p><code>b</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A gate.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cury                                                ::  curry left\n  |*  {a/_|=(^ **) b/*}\n  |*  c/_+&lt;+.a\n  (a b c)\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; =mol (cury add 2)\n&gt; (mol 4)\n6\n&gt; (mol 7)\n9\n</code></pre>"
+  },
+  {
+    "keys": [
+      "hard"
+    ],
+    "doc": "<h1><code>++hard</code></h1>\n\n<p>Demands that a specific type be produced, crashing the program is it is\nnot.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  hard                                                ::  force coerce to span\n  |*  han/mold\n  |=  fud/*  ^-  han\n  ~|  %hard\n  =+  gol=(han fud)\n  ?&gt;(=(gol fud) gol)\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((hard (list)) (limo [1 2 3 ~]))\n~[1 2 3]\n&gt; ((hard @) (add 2 2))\n4\n&gt; ((hard @t) (crip \"Tape to cord, bro!\"))\n'Tape to cord, bro'\n&gt; ((hard tape) (crip \"...Tape to cord, bro?...\"))\n! hard\n! exit\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "jar"
+    ],
+    "doc": "<h1><code>++jar</code></h1>\n\n\n<p>Tile generator. A <code>++jar</code> is a <code>++map</code> of <code>++list</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  jar  |*({a/$-(* *) b/$-(* *)} (map a (list b)))     ::  map of lists\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>See also: <code>++ja</code>, <code>++by</code>, <code>++map</code>, <code>++list</code></p>\n\n<pre><code>&gt; =a (limo [1 2 ~])\n&gt; a\n[i=1 t=[i=2 t=~]]\n&gt; =b (limo [3 4 ~])\n&gt; b\n[i=3 t=[i=4 t=~]]\n&gt; =c (mo (limo [[%a a] [%b b] ~]))\n&gt; c\n{[p=%a q=[i=1 t=[i=2 t=~]]] [p=%b q=[i=3 t=[i=4 t=~]]]}\n&gt; (~(get ja c) %a)\n[i=1 t=[i=2 t=~]]\n&gt; (~(get ja c) %c)\n~\n</code></pre>"
+  },
+  {
+    "keys": [
+      "jug"
+    ],
+    "doc": "<h1><code>++jug</code></h1>\n\n<p>mold generator.  A <code>++jug</code> is a <code>++map</code> of <code>++set</code>s.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  jug  |*({a/$-(* *) b/$-(* *)} (map a (set b)))      ::  map of sets\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>See also: <code>++ju</code>, <code>++by</code>, <code>++map</code>, <code>++set</code></p>\n\n<pre><code>&gt; =a (sa (limo [1 2 ~]))\n&gt; a\n{1 2}\n&gt; =b (sa (limo [3 4 ~]))\n&gt; b\n{4 3}\n&gt; =c (mo (limo [[%a a] [%b b] ~]))\n&gt; c\n{[p=%a q={1 2}] [p=%b q={4 3}]}\n&gt; (~(get ju c) %b)\n{4 3}\n&gt; (~(put ju c) [%b 5])\n{[p=%a q={1 2}] [p=%b q={5 4 3}]}\n</code></pre>"
+  },
+  {
+    "keys": [
+      "map"
+    ],
+    "doc": "<h1><code>++map</code></h1>\n\n<p>Map</p>\n\n<p>mold generator. A <code>++map</code> is a treap of\nkey-value pairs.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  map  |*  {a/$-(* *) b/$-(* *)}                      ::  associative tree\n         $@($~ {n/{p/a q/b} l/(map a b) r/(map a b)})   ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>See also: <code>++by</code></p>\n\n<pre><code>&gt;? *(map @t @u)\n          nlr({p/@t q/@u})\n          {}   \n&gt; (molt `(list (pair * *))`[[a+1 b+2] ~])\n          {[p=[97 1] q=[98 2]]}\n</code></pre>"
+  },
+  {
+    "keys": [
+      "qeu"
+    ],
+    "doc": "<h1><code>++qeu</code></h1>\n\n<p>Queue</p>\n\n<p>mold generator. An ordered <a href=\"http://en.wikipedia.org/wiki/Treap\">treap</a> of\nitems.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  qeu  |*  a/$-(* *)                                  ::  queue\n         $@($~ {n/a l/(qeu a) r/(qeu a)})               ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (qeu time)\n&lt;1.qyo [* &lt;1.sxx [a=&lt;1.ebd [* &lt;101.jzo 1.ypj %164&gt;]&gt; &lt;101.jzo 1.ypj %164&gt;]&gt;]&gt;\n&gt; (~(gas to *(qeu time)) [~2014.1.1 ~2014.1.2 ~])\n{~2014.1.2 ~2014.1.1}\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "cue"
+    ],
+    "doc": "<h1><code>++cue</code></h1>\n\n<p>Unpack atom to noun</p>\n\n<p>Produces a noun unpacked from atom <code>a</code>. The inverse of jam.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++noun</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cue                                                 ::  unpack\n  ~/  %cue\n  |=  a/@\n  ^-  *\n  =+  b=0\n  =+  m=`(map @ *)`~\n  =&lt;  q\n  |-  ^-  {p/@ q/* r/(map @ *)}\n  ?:  =(0 (cut 0 [b 1] a))\n    =+  c=(rub +(b) a)\n    [+(p.c) q.c (~(put by m) b q.c)]\n  =+  c=(add 2 b)\n  ?:  =(0 (cut 0 [+(b) 1] a))\n    =+  u=$(b c)\n    =+  v=$(b (add p.u c), m r.u)\n    =+  w=[q.u q.v]\n    [(add 2 (add p.u p.v)) w (~(put by r.v) b w)]\n  =+  d=(rub c a)\n  [(add 2 p.d) (need (~(get by m) q.d)) m]\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (cue 12)\n1\n&gt; (cue 817)\n[1 1]\n&gt; (cue 4.657)\n[1 2]\n&gt; (cue 39.689)\n[0 19]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "jam"
+    ],
+    "doc": "<h1><code>++jam</code></h1>\n\n<p>Pack noun to atom</p>\n\n<p>Produces an atom packed from noun <code>a</code>. The inverse of cue.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  jam                                                 ::  pack\n  ~/  %jam\n  |=  a/*\n  ^-  @\n  =+  b=0\n  =+  m=`(map * @)`~\n  =&lt;  q\n  |-  ^-  {p/@ q/@ r/(map * @)}\n  =+  c=(~(get by m) a)\n  ?~  c\n    =&gt;  .(m (~(put by m) a b))\n    ?:  ?=(@ a)\n      =+  d=(mat a)\n      [(add 1 p.d) (lsh 0 1 q.d) m]\n    =&gt;  .(b (add 2 b))\n    =+  d=$(a -.a)\n    =+  e=$(a +.a, b (add b p.d), m r.d)\n    [(add 2 (add p.d p.e)) (mix 1 (lsh 0 2 (cat 0 q.d q.e))) r.e]\n  ?:  ?&amp;(?=(@ a) (lte (met 0 a) (met 0 u.c)))\n    =+  d=(mat a)\n    [(add 1 p.d) (lsh 0 1 q.d) m]\n  =+  d=(mat u.c)\n  [(add 2 p.d) (mix 3 (lsh 0 2 q.d)) m]\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (jam 1)\n12\n&gt; (jam [1 1])\n817\n&gt; (jam [1 2])\n4.657\n&gt; (jam [~ u=19])\n39.689\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mat"
+    ],
+    "doc": "<h1><code>++mat</code></h1>\n\n<p>Length-encode</p>\n\n<p>Produces a cell whose tail <code>q</code> is atom <code>a</code> with a bit representation of\nits length prepended to it (as the least significant bits). The head <code>p</code>\nis the length of <code>q</code> in bits.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A cell of two atoms, <code>p</code> and <code>q</code>. </p>\n\n<h2>Source</h2>\n\n<pre><code>++  mat                                                 ::  length-encode\n  ~/  %mat\n  |=  a/@\n  ^-  {p/@ q/@}\n  ?:  =(0 a)\n    [1 1]\n  =+  b=(met 0 a)\n  =+  c=(met 0 b)\n  :-  (add (add c c) b)\n  (cat 0 (bex c) (mix (end 0 (dec c) b) (lsh 0 (dec c) a)))\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mat 0xaaa)\n[p=20 q=699.024]\n&gt; (met 0 q:(mat 0xaaa))\n20\n&gt; `@ub`q:(mat 0xaaa)\n0b1010.1010.1010.1001.0000\n&gt; =a =-(~&amp;(- -) `@ub`0xaaa)\n0b1010.1010.1010\n&gt; =b =-(~&amp;(- -) `@ub`(xeb a))\n0b1100\n&gt; =b =-(~&amp;(- -) `@ub`(met 0 a))\n0b1100\n&gt; =c =-(~&amp;(- -) (xeb b))\n4\n&gt;  [`@ub`a `@ub`(end 0 (dec c) b) `@ub`(bex c)]\n[0b1010.1010.1010 0b100 0b1.0000]\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "char"
+    ],
+    "doc": "<h1><code>++char</code></h1>\n\n<p>Char</p>\n\n<p>A single character. odor <code>@tD</code> designates a single unicode byte. All\nparsers consume <code>++tape</code>s, which are lists of <code>++char</code>.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  char  @tD                                          ::  UTF-8 byte\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *char\n''\n~zod/try&gt; (char 97)\n'a'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cord"
+    ],
+    "doc": "<h1><code>++cord</code></h1>\n\n<p>UTF-8 text</p>\n\n<p>One of Hoon's two string types (the other being <code>++tape</code>). A cord is an\natom of UTF-8 text. <code>++trip</code> and <code>++crip</code> convert between cord and\n<code>++tape</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cord  @t                                           ::  text atom (UTF-8)\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>Odor <code>@t</code> designates a Unicode atom, little-endian: the first character\nin the text is the low byte.</p>\n\n<pre><code>&gt; `@ux`'foobar'\n0x7261.626f.6f66\n\n&gt; `@`'urbit'\n499.984.265.845\n&gt; (cord 499.984.265.845)\n'urbit'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "date"
+    ],
+    "doc": "<h1><code>++date</code></h1>\n\n<p>Point in time</p>\n\n<p>A boolean designating AD or BC, a year atom, a month\natom, and a <code>++tarp</code>, which is a day atom and a time.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  date  {{a/? y/@ud} m/@ud t/tarp}                    ::  parsed date\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>See also: <code>++year</code>, <code>++yore</code> <code>++stud</code>, <code>++dust</code></p>\n\n<pre><code>&gt; `date`(yore ~2014.6.6..21.09.15..0a16)\n[[a=%.y y=2.014] m=6 t=[d=6 h=21 m=9 s=15 f=~[0xa16]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tang"
+    ],
+    "doc": "<h1><code>++tang</code></h1>\n\n<pre><code>++  tang  (list tank)                                   ::  general error\n</code></pre>\n\n<p>Unused XX</p>"
+  },
+  {
+    "keys": [
+      "tank"
+    ],
+    "doc": "<h1><code>++tank</code></h1>\n\n<p>Pretty-printing structure.</p>\n\n<p>A <code>++tank</code> is one of three cases: a <code>%leaf</code>\nis simply a string; a <code>%palm</code> is XX need more information; and a <code>%rose</code> is a\nlist of <code>++tank</code> delimted by the strings in <code>p</code>.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>++  tank  $%  {$leaf p/tape}                            ::  printing formats\n              $:  $palm                                 ::  backstep list\n                  p/{p/tape q/tape r/tape s/tape}       ::\n                  q/(list tank)                         ::\n              ==                                        ::\n              $:  $rose                                 ::  flat list\n                  p/{p/tape q/tape r/tape}              ::  mid open close\n                  q/(list tank)                         ::\n              ==                                        ::\n          ==                                            ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; &gt;(bex 20) (bex 19)&lt;\n[%rose p=[p=\" \" q=\"[\" r=\"]\"] q=~[[%leaf p=\"1.048.576\"] [%leaf p=\"524.288\"]]]\n&gt; (wash [0 80] &gt;(bex 20) (bex 19)&lt;)  :: at 80 cols\n&lt;&lt;\"[1.048.576 524.288]\"&gt;&gt;\n&gt; (wash [0 15] &gt;(bex 20) (bex 19)&lt;)  :: at 15 cols (two lines)\n&lt;&lt;\"[ 1.048.576\" \"  524.288\" \"]\"&gt;&gt;\n\n&gt; [(bex 150) (bex 151)]  :: at 80 cols\n[ 1.427.247.692.705.959.881.058.285.969.449.495.136.382.746.624\n  2.854.495.385.411.919.762.116.571.938.898.990.272.765.493.248\n]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tape"
+    ],
+    "doc": "<h1><code>++tape</code></h1>\n\n<p>List of chars</p>\n\n<p>One of Hoon's two string types, the other being <code>++cord</code>. A tape is a\nlist of chars.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  tape  (list char)                                   ::  like a string\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `(list char)`\"foobar\"\n\"foobar\"\n&gt; `(list @)`\"foobar\"\n~[102 111 111 98 97 114]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tarp"
+    ],
+    "doc": "<h1><code>++tarp</code></h1>\n\n<p>Day through second</p>\n\n<p>The remaining part of a <code>++date</code>: day, hour, minute, second and a list\nof <code>@ux</code> for precision.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  tarp  {d/@ud h/@ud m/@ud s/@ud f/(list @ux)}        ::  parsed time\n</code></pre>\n\n\n<h2>Examples</h2>\n\n\n<pre><code>&gt; -&lt;-\n~2014.9.20..00.43.33..b52a\n&gt; :: the time is always in your context at -&lt;-\n&gt; (yell -&lt;-)\n[d=106.751.991.820.278 h=0 m=43 s=39 f=~[0x54d1]]\n\n&gt; (yell ~d20)\n[d=20 h=0 m=0 s=0 f=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "term"
+    ],
+    "doc": "<h1><code>++term</code></h1>\n\n<p>Hoon constants</p>\n\n<p>A restricted text atom for Hoon constants. The only characters permitted are\nlowercase ASCII, <code>-</code>, and <code>0-9</code>, the latter two of which can neither be the first or last\ncharacter. The syntax for <code>@tas</code> is the text itself, always preceded by <code>%</code>.\nThis means a term is always cubical. The empty <code>@tas</code> has a special syntax,\n<code>$</code>.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>    ++  term  @tas                                         ::  Hoon ASCII subset\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *term\n%$\n\n&gt; %dead-fish9\n%dead-fish9\n&gt; -:!&gt;(%dead-fish9)\n[%cube p=271.101.667.197.767.630.546.276 q=[%atom p=%tas]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "wain"
+    ],
+    "doc": "<h1><code>++wain</code></h1>\n\n<pre><code>++  wain  (list cord)                                   ::  text lines (no \\n)\n</code></pre>\n\n<p>A list of lines. A <code>++wain</code> is used instead of a single <code>++cord</code> with\n<code>\\n</code>.</p>\n\n<p>See also: <code>++lore</code>, <code>++role</code></p>\n\n<pre><code>&gt; `wain`/som/del/rok\n&lt;|som del rok|&gt;\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "fe"
+    ],
+    "doc": "<h1><code>++fe</code>                                                 ::  modulo bloq</h1>\n\n<p>Modulo bloq</p>\n\n<p>Core containing XX</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++bloq</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>|_  a=bloq\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dif"
+    ],
+    "doc": "<h1><code>++dif</code></h1>\n\n<p>Produces the difference between two atoms in the modular basis\nrepresentation.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++bloq</code>.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@s</code></p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  dif  |=([b/@ c/@] (sit (sub (add out (sit b)) (sit c))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(dif fe 3) 63 64)\n255\n&gt; (~(dif fe 3) 5 10)\n251\n&gt; (~(dif fe 3) 0 1)\n255\n&gt; (~(dif fe 0) 9 10)\n1\n&gt; (~(dif fe 0) 9 11)\n0\n&gt; (~(dif fe 0) 9 12)\n1\n&gt; (~(dif fe 2) 9 12)\n13\n&gt; (~(dif fe 2) 63 64)\n15\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "inv"
+    ],
+    "doc": "<h1><code>++inv</code></h1>\n\n<p>Invert mod field</p>\n\n<p>Inverts the order of the modular field.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a <code>++bloq</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>  ++  inv  |=(b/@ (sub (dec out) (sit b)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(inv fe 3) 255)\n0\n&gt; (~(inv fe 3) 256)\n255\n&gt; (~(inv fe 3) 0)\n255\n&gt; (~(inv fe 3) 1)\n254\n&gt; (~(inv fe 3) 2)\n253\n&gt; (~(inv fe 3) 55)\n200\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "net"
+    ],
+    "doc": "<h1><code>++net</code></h1>\n\n<p>Reverse bytes</p>\n\n<p>Revereses bytes within block.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a <code>++bloq</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  net  |=  b/@  ^-  @\n           =&gt;  .(b (sit b))\n           ?:  (lte a 3)\n             b\n           =+  c=(dec a)\n           %+  con\n             (lsh c 1 $(a c, b (cut c [0 1] b)))\n           $(a c, b (cut c [1 1] b))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(net fe 3) 64)\n64\n&gt; (~(net fe 3) 128)\n128\n&gt; (~(net fe 3) 255)\n255\n&gt; (~(net fe 3) 256)\n0\n&gt; (~(net fe 3) 257)\n1\n&gt; (~(net fe 3) 500)\n244\n&gt; (~(net fe 3) 511)\n255\n&gt; (~(net fe 3) 512)\n0\n&gt; (~(net fe 3) 513)\n1\n&gt; (~(net fe 3) 0)\n0\n&gt; (~(net fe 3) 1)\n1\n&gt; (~(net fe 0) 1)\n1\n&gt; (~(net fe 0) 2)\n0\n&gt; (~(net fe 0) 3)\n1\n&gt; (~(net fe 6) 1)\n72.057.594.037.927.936\n&gt; (~(net fe 6) 2)\n144.115.188.075.855.872\n&gt; (~(net fe 6) 3)\n216.172.782.113.783.808\n&gt; (~(net fe 6) 4)\n288.230.376.151.711.744\n&gt; (~(net fe 6) 5)\n360.287.970.189.639.680\n&gt; (~(net fe 6) 6)\n432.345.564.227.567.616\n&gt; (~(net fe 6) 7)\n504.403.158.265.495.552\n&gt; (~(net fe 6) 512)\n562.949.953.421.312\n&gt; (~(net fe 6) 513)\n72.620.543.991.349.248\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "out"
+    ],
+    "doc": "<h1><code>++out</code></h1>\n\n<p>Max integer value</p>\n\n<p>The maximum integer value that the current block can store.</p>\n\n<h2>Accepts</h2>\n\n<p>A <code>++bloq</code>. </p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  out  (bex (bex a))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ~(out fe 0)\n2\n&gt; ~(out fe 1)\n4\n&gt; ~(out fe 2)\n16\n&gt; ~(out fe 3)\n256\n&gt; ~(out fe 4)\n65.536\n&gt; ~(out fe 10)\n\\/179.769.313.486.231.590.772.930.519.078.902.473.361.797.697.894.230.657.\\/\n  273.430.081.157.732.675.805.500.963.132.708.477.322.407.536.021.120.113.\n  879.871.393.357.658.789.768.814.416.622.492.847.430.639.474.124.377.767.\n  893.424.865.485.276.302.219.601.246.094.119.453.082.952.085.005.768.838.\n  150.682.342.462.881.473.913.110.540.827.237.163.350.510.684.586.298.239.\n  947.245.938.479.716.304.835.356.329.624.224.137.216\n\\/                                                                        \\/\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rol"
+    ],
+    "doc": "<h1><code>++rol</code></h1>\n\n<p>Roll left</p>\n\n<p>Roll <code>d</code> to the left by <code>c</code> <code>b</code>-sized blocks.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++bloq</code>.</p>\n\n<p><code>b</code> is a <code>++bloq</code>.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<p><code>d</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  rol  |=  [b/bloq c/@ d/@]  ^-  @                  ::  roll left\n           =+  e=(sit d)\n           =+  f=(bex (sub a b))\n           =+  g=(mod c f)\n           (sit (con (lsh b g e) (rsh b (sub f g) e)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ux`(~(rol fe 6) 4 3 0xabac.dedf.1213)\n0x1213.0000.abac.dedf\n&gt; `@ux`(~(rol fe 6) 4 2 0xabac.dedf.1213)\n0xdedf.1213.0000.abac\n&gt; `@t`(~(rol fe 5) 3 1 'dfgh')\n'hdfg'\n&gt; `@t`(~(rol fe 5) 3 2 'dfgh')\n'ghdf'\n&gt; `@t`(~(rol fe 5) 3 0 'dfgh')\n'dfgh'\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "ror"
+    ],
+    "doc": "<h1><code>++ror</code></h1>\n\n<p>Roll right</p>\n\n<p>Roll <code>d</code> to the right by <code>c</code> <code>b</code>-sized blocks.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++bloq</code>.</p>\n\n<p><code>b</code> is a <code>++bloq</code>.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<p><code>d</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  ror  |=  {b/bloq c/@ d/@}  ^-  @                  ::  roll right\n           =+  e=(sit d)\n           =+  f=(bex (sub a b))\n           =+  g=(mod c f)\n           (sit (con (rsh b g e) (lsh b (sub f g) e)))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ux`(~(ror fe 6) 4 1 0xabac.dedf.1213)\n0x1213.0000.abac.dedf\n&gt; `@ux`(~(ror fe 6) 3 5 0xabac.dedf.1213)\n0xacde.df12.1300.00ab\n&gt; `@ux`(~(ror fe 6) 3 3 0xabac.dedf.1213)\n0xdf12.1300.00ab.acde\n&gt; `@t`(~(rol fe 5) 3 0 'hijk')\n'hijk'\n&gt; `@t`(~(rol fe 5) 3 1 'hijk')\n'khij'\n&gt; `@t`(~(rol fe 5) 3 2 'hijk')\n'jkhi'\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sum"
+    ],
+    "doc": "<h1><code>++sum</code></h1>\n\n<p>Sum</p>\n\n<p>Sum two numbers in this modular field.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++bloq</code>.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<p><code>c</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sum  |=([b/@ c/@] (sit (add b c)))                ::  wrapping add\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(sum fe 3) 10 250)\n4\n&gt; (~(sum fe 0) 0 1)\n1\n&gt; (~(sum fe 0) 0 2)\n0\n&gt; (~(sum fe 2) 14 2)\n0\n&gt; (~(sum fe 2) 14 3)\n1\n&gt; (~(sum fe 4) 10.000 256)\n10.256\n&gt; (~(sum fe 4) 10.000 100.000)\n44.464\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sit"
+    ],
+    "doc": "<h1><code>++sit</code></h1>\n\n<p>Atom in mod block representation</p>\n\n<p>Produce an atom in the current modular block representation.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++bloq</code>.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sit  |=(b/@ (end a 1 b))                          ::  enforce modulo\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(sit fe 3) 255)\n255\n&gt; (~(sit fe 3) 256)\n0\n&gt; (~(sit fe 3) 257)\n1\n&gt; (~(sit fe 2) 257)\n1\n&gt; (~(sit fe 2) 10.000)\n0\n&gt; (~(sit fe 2) 100)\n4\n&gt; (~(sit fe 2) 19)\n3\n&gt; (~(sit fe 2) 17)\n1\n&gt; (~(sit fe 0) 17)\n1\n&gt; (~(sit fe 0) 0)\n0\n&gt; (~(sit fe 0) 1)\n1\n</code></pre>"
+  },
+  {
+    "keys": [
+      "si"
+    ],
+    "doc": "<h1><code>++si</code></h1>\n\n<pre><code>++  si  !:                                              ::  signed integer\n  |%\n</code></pre>\n\n<p>Container core for the signed integer functions.</p>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "abs"
+    ],
+    "doc": "<h1><code>++abs</code></h1>\n\n<p>Absolute value</p>\n\n<p>Produces the absolute value of a signed integer.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a signed integer, <code>@s</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  abs  |=(a/@s (add (end 0 1 a) (rsh 0 1 a)))       ::  absolute value\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (abs:si -2)\n2\n&gt; (abs:si -10.000)\n10.000\n&gt; (abs:si --2)\n2\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "dif"
+    ],
+    "doc": "<h1><code>++dif</code></h1>\n\n<p>Difference</p>\n\n<p>Produces the difference between two signed integers <code>b</code> and <code>c</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a signed integer, <code>@s</code>.</p>\n\n<p><code>b</code> is a signed integer, <code>@s</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@s</code>.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>  ++  dif  |=  [a/@s b/@s]                              ::  subtraction\n           (sum a (new !(syn b) (abs b)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (dif:si --10 -7)\n--17\n&gt; (dif:si --10 --7)\n--3\n&gt; (dif:si `@s`0 --7)\n-7\n&gt; (dif:si `@s`0 `@s`7)\n--4\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "dul"
+    ],
+    "doc": "<h1><code>++dul</code></h1>\n\n<p>Modulus</p>\n\n<p>Produces the modulus of two signed integers.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a signed integer, <code>@s</code>.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom. </p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  dul  |=  [a/@s b/@]                               ::  modulus\n           =+(c=(old a) ?:(-.c (mod +.c b) (sub b +.c)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (dul:si --9 3)\n0\n&gt; (dul:si --9 4)\n1\n&gt; (dul:si --9 5)\n4\n&gt; (dul:si --9 6)\n3\n&gt; (dul:si --90 --10)\n10\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "fra"
+    ],
+    "doc": "<h1><code>++fra</code></h1>\n\n<p>Divide</p>\n\n<p>Produces the quotient of two signed integers.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a signed integer, <code>@s</code>.</p>\n\n<p><code>b</code> is a signed integer, <code>@s</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  fra  |=  [a/@s b/@s]                              ::  divide\n           (new =(0 (mix (syn a) (syn b))) (div (abs a) (abs b)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (fra:si --10 -2)\n-5\n&gt; (fra:si -20 -5)\n--4\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "new"
+    ],
+    "doc": "<h1><code>++new</code></h1>\n\n<p>Signed integer</p>\n\n<p>Produces a signed integer from a loobean sign value <code>a</code> and an atom <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a loobean.</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@s</code></p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  new  |=  [a/? b/@]                                ::  [sign value] to @s\n           `@s`?:(a (mul 2 b) ?:(=(0 b) 0 +((mul 2 (dec b)))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (new:si [&amp; 10])\n--10\n&gt; (new:si [| 10])\n-10\n&gt; (new:si [%.y 7])\n--7\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "old"
+    ],
+    "doc": "<h1><code>++old</code></h1>\n\n<p>sign value</p>\n\n<p>Produces the cell <code>[sign value]</code> representations of a signed integer.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>@s</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A cell of a boolean and an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  old  |=(a/@s [(syn a) (abs a)])                   ::  [sign value]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (old:si 7)\n! type-fail\n! exit\n&gt; (old:si -7)\n[%.n 7]\n&gt; (old:si --7)\n[%.y 7]\n&gt; (old:si `@s`7)\n[%.n 4]\n&gt; (old:si -0)\n[%.y 0]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "pro"
+    ],
+    "doc": "<h1><code>++pro</code></h1>\n\n<p>Multiply</p>\n\n<p>Produces the product of two signed integers.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>@s</code>.</p>\n\n<p><code>b</code> is a  <code>@s</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@s</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  pro  |=  [a/@s b/@s]                              ::  multiplication\n           (new =(0 (mix (syn a) (syn b))) (mul (abs a) (abs b)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (pro:si -4 --2)\n-8\n&gt; (pro:si -4 -2)\n--8\n&gt; (pro:si --10.000.000 -10)\n-100.000.000\n&gt; (pro:si -1.337 --0)\n--0\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rem"
+    ],
+    "doc": "<h1><code>++rem</code></h1>\n\n<p>Remainder</p>\n\n<p>Produces the remainder from a division of two signed integers.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>@s</code>.</p>\n\n<p><code>b</code> is a <code>@s</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@sd</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  rem  |=([a/@s b/@s] (dif a (pro b (fra a b))))    ::  remainder\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (rem:si -10 -4)\n-2\n&gt; (rem:si --10 --4)\n--2\n&gt; (rem:si --10 -4)\n--2\n&gt; (rem:si --7 --3)\n--1\n&gt; (rem:si --0 --10.000)\n--0\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sum"
+    ],
+    "doc": "<h1><code>++sum</code></h1>\n\n<p>Add</p>\n\n<p>Sum two signed integers.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a <code>@s</code>.</p>\n\n<p><code>c</code> is a signed integer <code>@s</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@s</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sum  |=  [a/@s b/@s]                              ::  addition\n           ~|  %si-sum\n           =+  [c=(old a) d=(old b)]\n           ?:  -.c\n             ?:  -.d\n               (new &amp; (add +.c +.d))\n             ?:  (gte +.c +.d)\n               (new &amp; (sub +.c +.d))\n             (new | (sub +.d +.c))\n           ?:  -.d\n             ?:  (gte +.c +.d)\n               (new | (sub +.c +.d))\n             (new &amp; (sub +.d +.c))\n           (new | (add +.c +.d))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (sum:si --10 --10)\n--20\n&gt; (sum:si --10 -0)\n--10\n&gt; (sum:si -10 -7)\n-17\n&gt; (sum:si -10 --7)\n-3\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sun"
+    ],
+    "doc": "<h1><code>++sun</code></h1>\n\n<p>Signed from unsigned</p>\n\n<p>Produces a signed integer from an unsigned integer.</p>\n\n<p>Note that the result must be manually cast to some <code>@s</code> odor to be\ninferred as an unsigned integer in the type system.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>@u</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@s</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sun  |=(a/@u (mul 2 a))                           ::  @u to @s\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@s`10\n--5\n&gt; (sun:si 10)\n20\n&gt; `@s`(sun:si 10)\n--10\n&gt; `@sd`(sun:si 10)\n--10\n&gt; `@sd`(sun:si 12.345)\n--12.345\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "syn"
+    ],
+    "doc": "<h1><code>++syn</code></h1>\n\n<p>Sign</p>\n\n<p>Produce the sign of a signed integer, where <code>&amp;</code> is posiitve, and <code>|</code> is negative.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>@s</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  syn  |=(a/@s =(0 (end 0 1 a)))                    ::  sign test\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (syn:si -2)\n%.n\n&gt; (syn:si --2)\n%.y\n&gt; (syn:si -0)\n%.y\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "cmp"
+    ],
+    "doc": "<h1><code>++cmp</code></h1>\n\n<p>Compare</p>\n\n<p>Compare two signed integers.</p>\n\n<h2>Accepts</h2>\n\n<p><code>b</code> is a  <code>@s</code>.</p>\n\n<p><code>c</code> is a  <code>@s</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@s</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  cmp  |=  [a/@s b/@s]                              ::  compare\n           ^-  @s\n           ?:  =(a b)\n             --0\n           ?:  (syn a)\n             ?:  (syn b)\n               ?:  (gth a b)\n                 --1\n               -1\n             --1\n          ?:  (syn b)\n            -1\n          ?:  (gth a b)\n            -1\n          --1\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (cmp:si --10 --10)\n--0\n&gt; (cmp:si --10 -0)\n--1\n&gt; (cmp:si -10 -7)\n-1\n&gt; (cmp:si -10 --7)\n-1\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "yo"
+    ],
+    "doc": "<h1><code>++yo</code></h1>\n\n<pre><code>++  yo                                                  ::  time constants core\n</code></pre>\n\n<p>Useful constants for interacting with earth time.</p>"
+  },
+  {
+    "keys": [
+      "cet"
+    ],
+    "doc": "<h1><code>++cet</code></h1>\n\n<p>Days in a century. Derived by multiplying the number of days in a year\n(365) by the number of years in a century (100), then adding the number\ndays from leap years in a century (24).</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  |%  ++  cet  36.524                 ::  (add 24 (mul 100 365))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; cet:yo\n36.524\n&gt; (add 365 cet:yo)\n36.889\n&gt; (sub (add 24 (mul 100 365)) cet:yo)\n0\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "day"
+    ],
+    "doc": "<h1><code>++day</code></h1>\n\n<p>Number of seconds in a day.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  day  86.400                 ::  (mul 24 hor)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; day:yo\n86.400\n&gt; (add 60 day:yo)\n86.460\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "era"
+    ],
+    "doc": "<h1><code>++era</code></h1>\n\n<p>XX Revisit</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  era  146.097                ::  (add 1 (mul 4 cet))\n</code></pre>\n\n<h2>Examples</h2>\n\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "hor"
+    ],
+    "doc": "<h1><code>++hor</code></h1>\n\n<p>Seconds in hour</p>\n\n<p>The number of seconds in an hour. Derived by multiplying the number of\nseconds in a minute by the minutes in an hour.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  hor  3.600                  ::  (mul 60 mit)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; hor:yo\n3.600\n&gt; (div hor:yo 60)\n60\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "jes"
+    ],
+    "doc": "<h1><code>++jes</code></h1>\n\n<p>XX Revisit</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  jes  106.751.991.084.417    ::  (mul 730.692.561 era)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; jes:yo\n106.751.991.084.417\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "mit"
+    ],
+    "doc": "<h1><code>++mit</code></h1>\n\n<p>Seconds in minute</p>\n\n<p>The number of seconds in a minute.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  mit  60\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; mit:yo\n60\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "moh"
+    ],
+    "doc": "<h1><code>++moh</code></h1>\n\n<p>Days in month</p>\n\n<p>The days in each month of the Gregorian common year. A list of unsigned\ndecimal atoms (Either 28, 30, or 31) denoting the number of days in the\nmonth at the year at that index.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++list</code> of <code>@ud</code></p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  moh  `(list @ud)`[31 28 31 30 31 30 31 31 30 31 30 31 ~]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; moh:yo\n~[31 28 31 30 31 30 31 31 30 31 30 31]\n&gt; (snag 4 moh:yo)\n31\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "moy"
+    ],
+    "doc": "<h1><code>++moy</code></h1>\n\n<p>Moh with leapyear</p>\n\n<p>The days in each month of the Gregorian leap-year. A list of unsigned\ndecimal atoms (Either 29,30, or 31) denoting the number of days in the\nmonth at the leap-year at that index.</p>\n\n<h2>Examples</h2>\n\n<p>A <code>++list</code> of <code>@ud</code></p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  moy  `(list @ud)`[31 29 31 30 31 30 31 31 30 31 30 31 ~]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; moy:yo\n~[31 29 31 30 31 30 31 31 30 31 30 31]\n&gt; (snag 1 moy:yo)\n29\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "qad"
+    ],
+    "doc": "<h1><code>++qad</code></h1>\n\n<p>Seconds in 4 years</p>\n\n<p>The number of seconds in four years. Derived by adding one second to the\nnumber of seconds in four years.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  qad  126.144.001            ::  (add 1 (mul 4 yer))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; qad:yo\n126.144.001\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "yer"
+    ],
+    "doc": "<h1><code>++yer</code></h1>\n\n<p>Seconds in year</p>\n\n<p>The number of seconds in a year. Derived by multiplying the number of\nseconds in a day by 365.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  yer  31.536.000             ::  (mul 365 day)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; yer:yo\n31.536.000\n</code></pre>"
+  },
+  {
+    "keys": [
+      "yall"
+    ],
+    "doc": "<h1><code>++yall</code></h1>\n\n<p>Time since beginning of time</p>\n\n<p>Produce the date tuple of <code>[y=@ud m=@ud d=@ud]</code> of the year, month, and\nday from a number of days from the beginning of time.</p>\n\n<h2>Accepts</h2>\n\n<p><code>day</code> is a <a href=\"\"><code>@ud</code></a></p>\n\n<h2>Produces</h2>\n\n\n<h2>Source</h2>\n\n<pre><code>++  yall                                                ::  day / to day of year\n  |=  day/@ud\n  ^-  {y/@ud m/@ud d/@ud}\n  =+  [era=0 cet=0 lep=*?]\n  =&gt;  .(era (div day era:yo), day (mod day era:yo))\n  =&gt;  ^+  .\n      ?:  (lth day +(cet:yo))\n        .(lep &amp;, cet 0)\n      =&gt;  .(lep |, cet 1, day (sub day +(cet:yo)))\n      .(cet (add cet (div day cet:yo)), day (mod day cet:yo))\n  =+  yer=(add (mul 400 era) (mul 100 cet))\n  |-  ^-  {y/@ud m/@ud d/@ud}\n  =+  dis=?:(lep 366 365)\n  ?.  (lth day dis)\n    =+  ner=+(yer)\n    $(yer ner, day (sub day dis), lep =(0 (end 0 2 ner)))\n  |-  ^-  {y/@ud m/@ud d/@ud}\n  =+  [mot=0 cah=?:(lep moy:yo moh:yo)]\n  |-  ^-  {y/@ud m/@ud d/@ud}\n  =+  zis=(snag mot cah)\n  ?:  (lth day zis)\n    [yer +(mot) +(day)]\n  $(mot +(mot), day (sub day zis))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (yall 198)\n[y=0 m=7 d=17]\n&gt; (yall 90.398)\n[y=247 m=7 d=3]\n&gt; (yall 0)\n[y=0 m=1 d=1]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "yawn"
+    ],
+    "doc": "<h1><code>++yawn</code></h1>\n\n<p>Days since beginning of time</p>\n\n<p>Inverse of <code>yall</code>, computes number of days A.D. from y/m/d date as the\ntuple <code>[yer=@ud mot=@ud day=@ud]</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>yer</code> is an unsigned decimal, <code>@ud</code>.</p>\n\n<p><code>mon</code> is an unsigned decimal, <code>@ud</code>.</p>\n\n<p><code>day</code> is an unsigned decimal, <code>@ud</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@ud</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  yawn                                                ::  days since Jesus\n  |=  {yer/@ud mot/@ud day/@ud}\n  ^-  @ud\n  =&gt;  .(mot (dec mot), day (dec day))\n  =&gt;  ^+  .\n      %=    .\n          day\n        =+  cah=?:((yelp yer) moy:yo moh:yo)\n        |-  ^-  @ud\n        ?:  =(0 mot)\n          day\n        $(mot (dec mot), cah (slag 1 cah), day (add day (snag 0 cah)))\n      ==\n  |-  ^-  @ud\n  ?.  =(0 (mod yer 4))\n    =+  ney=(dec yer)\n    $(yer ney, day (add day ?:((yelp ney) 366 365)))\n  ?.  =(0 (mod yer 100))\n    =+  nef=(sub yer 4)\n    $(yer nef, day (add day ?:((yelp nef) 1.461 1.460)))\n  ?.  =(0 (mod yer 400))\n    =+  nec=(sub yer 100)\n    $(yer nec, day (add day ?:((yelp nec) 36.525 36.524)))\n  (add day (mul (div yer 400) (add 1 (mul 4 36.524))))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (yawn 2.014 8 4)\n735.814\n&gt; (yawn 1.776 7 4)\n648.856\n&gt; (yawn 1.990 10 11)\n727.116\n</code></pre>"
+  },
+  {
+    "keys": [
+      "year"
+    ],
+    "doc": "<h1><code>++year</code></h1>\n\n<p>Accept a parsed date of form <code>[[a=? y=@ud] m=@ud t=tarp]</code> and produce\nits <code>@d</code>representation.</p>\n\n<h2>Accepts</h2>\n\n<p><code>det</code> is a <code>++date</code></p>\n\n<h2>Produces</h2>\n\n<p>A <code>@d</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  year                                                ::  date to @d\n  |=  det/date\n  ^-  @da\n  =+  ^=  yer\n      ?:  a.det\n        (add 292.277.024.400 y.det)\n      (sub 292.277.024.400 (dec y.det))\n  =+  day=(yawn yer m.det d.t.det)\n  (yule day h.t.det m.t.det s.t.det f.t.det)\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (year [[a=%.y y=2.014] m=8 t=[d=4 h=20 m=4 s=57 f=~[0xd940]]])\n0x8000000d227df4e9d940000000000000\n</code></pre>"
+  },
+  {
+    "keys": [
+      "yell"
+    ],
+    "doc": "<h1><code>++yell</code></h1>\n\n<p>Produce a parsed daily time format from an atomic date.</p>\n\n<p><code>now</code> is a <code>@d</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  yell                                                ::  tarp from @d\n  |=  now/@d\n  ^-  tarp\n  =+  sec=(rsh 6 1 now)\n  =+  ^=  fan\n      =+  [muc=4 raw=(end 6 1 now)]\n      |-  ^-  (list @ux)\n      ?:  |(=(0 raw) =(0 muc))\n        ~\n      =&gt;  .(muc (dec muc))\n      [(cut 4 [muc 1] raw) $(raw (end 4 muc raw))]\n  =+  day=(div sec day:yo)\n  =&gt;  .(sec (mod sec day:yo))\n  =+  hor=(div sec hor:yo)\n  =&gt;  .(sec (mod sec hor:yo))\n  =+  mit=(div sec mit:yo)\n  =&gt;  .(sec (mod sec mit:yo))\n  [day hor mit sec fan]\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (yell ~2014.3.20..05.42.53..7456)\n[d=106.751.991.820.094 h=5 m=42 s=53 f=~[0x7456]]\n&gt; (yell ~2014.6.9..19.09.40..8b66)\n[d=106.751.991.820.175 h=19 m=9 s=40 f=~[0x8b66]]\n&gt; (yell ~1776.7.4)\n[d=106.751.991.733.273 h=0 m=0 s=0 f=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "yelp"
+    ],
+    "doc": "<h1><code>++yelp</code></h1>\n\n<p>Leap-week?</p>\n\n<p>Determines whether a year contains an ISO 8601 leap week. Produces a\nloobean.</p>\n\n<h2>Accepts</h2>\n\n<p><code>yer</code> is an unsigned decimal, <code>@ud</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  yelp                                                ::  leap year\n  |=  yer=@ud  ^-  ?\n  &amp;(=(0 (mod yer 4)) |(!=(0 (mod yer 100)) =(0 (mod yer 400))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (yelp 2.014)\n%.n\n&gt; (yelp 2.008)\n%.y\n&gt; (yelp 0)\n%.y\n&gt; (yelp 14.011)\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "yore"
+    ],
+    "doc": "<h1><code>++yore</code></h1>\n\n<p>Produces a <code>++date</code> from a <code>@d</code></p>\n\n<h2>Accepts</h2>\n\n<p><code>now</code> is a <code>@d</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++date</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  yore                                                ::  @d to date\n  |=  now/@da\n  ^-  date\n  =+  rip=(yell now)\n  =+  ger=(yall d.rip)\n  :-  ?:  (gth y.ger 292.277.024.400)\n        [a=&amp; y=(sub y.ger 292.277.024.400)]\n      [a=| y=+((sub 292.277.024.400 y.ger))]\n  [m.ger d.ger h.rip m.rip s.rip f.rip]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (yore -&lt;-)\n[[a=%.y y=2.014] m=8 t=[d=4 h=20 m=17 s=1 f=~[0x700d]]]\n&gt; (yore -&lt;-)\n[[a=%.y y=2.014] m=8 t=[d=4 h=20 m=28 s=53 f=~[0x7b82]]]\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "og"
+    ],
+    "doc": "<h1><code>++og</code></h1>\n\n<pre><code>++  og                                                  ::  shax-powered rng\n  ~/  %og\n  |_  a/@\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rad"
+    ],
+    "doc": "<h1><code>++rad</code></h1>\n\n<pre><code>  ++  rad                                               ::  random in range\n    |=  b/@  ^-  @\n    =+  c=(raw (met 0 b))\n    ?:((lth c b) c $(a +(a)))\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rads"
+    ],
+    "doc": "<h1><code>++rads</code></h1>\n\n<pre><code>  ++  rads                                              ::  random continuation\n    |=  b/@\n    =+  r=(rad b)\n    [r +&gt;.$(a (shas %og-s r))]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "raw"
+    ],
+    "doc": "<h1><code>++raw</code></h1>\n\n<pre><code>  ++  raw                                               ::  random bits\n    ~/  %raw\n    |=  b/@  ^-  @\n    %+  can\n      0\n    =+  c=(shas %og-a (mix b a))\n    |-  ^-  (list [@ @])\n    ?:  =(0 b)\n      ~\n    =+  d=(shas %og-b (mix b (mix a c)))\n    ?:  (lth b 256)\n      [[b (end 0 b d)] ~]\n    [[256 d] $(c d, b (sub b 256))]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "raws"
+    ],
+    "doc": "<h1><code>++raws</code></h1>\n\n<pre><code>  ++  raws                                              ::  random bits continuation\n    |=  b/@\n    =+  r=(raw b)\n    [r +&gt;.$(a (shas %og-s r))]\n  --\n</code></pre>"
+  },
+  {
+    "keys": [
+      "shad"
+    ],
+    "doc": "<h1><code>++shad</code></h1>\n\n<pre><code>++  shad  |=(ruz/@ (shax (shax ruz)))                   ::  double sha-256\n</code></pre>\n\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "shaf"
+    ],
+    "doc": "<h1><code>++shaf</code></h1>\n\n<pre><code>++  shaf                                                ::  half sha-256\n  |=  [sal/@ ruz/@]\n  =+  haz=(shas sal ruz)\n  (mix (end 7 1 haz) (rsh 7 1 haz))\n::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "shak"
+    ],
+    "doc": "<h1><code>++shak</code></h1>\n\n<pre><code>++  shak                                                ::  XX shd be PBKDF\n  |=  [who/@p wud/@]\n  (shas (mix %shak who) wud)\n::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "shal"
+    ],
+    "doc": "<h1><code>++shal</code></h1>\n\n<pre><code>++  shal                                                ::  sha-512 with length\n  ~/  %shal\n  |=  {len/@ ruz/@}  ^-  @\n  =&gt;  .(ruz (cut 3 [0 len] ruz))\n  =+  [few==&gt;(fe .(a 6)) wac=|=({a/@ b/@} (cut 6 [a 1] b))]\n  =+  [sum=sum.few ror=ror.few net=net.few inv=inv.few]\n  =+  ral=(lsh 0 3 len)\n  =+  ^=  ful\n      %+  can  0\n      :~  [ral ruz]\n          [8 128]\n          [(mod (sub 1.920 (mod (add 8 ral) 1.024)) 1.024) 0]\n          [128 (~(net fe 7) ral)]\n      ==\n  =+  lex=(met 10 ful)\n  =+  ^=  kbx  0x6c44.198c.4a47.5817.5fcb.6fab.3ad6.faec.\n                 597f.299c.fc65.7e2a.4cc5.d4be.cb3e.42b6.\n                 431d.67c4.9c10.0d4c.3c9e.be0a.15c9.bebc.\n                 32ca.ab7b.40c7.2493.28db.77f5.2304.7d84.\n                 1b71.0b35.131c.471b.113f.9804.bef9.0dae.\n                 0a63.7dc5.a2c8.98a6.06f0.67aa.7217.6fba.\n                 f57d.4f7f.ee6e.d178.eada.7dd6.cde0.eb1e.\n                 d186.b8c7.21c0.c207.ca27.3ece.ea26.619c.\n                 c671.78f2.e372.532b.bef9.a3f7.b2c6.7915.\n                 a450.6ceb.de82.bde9.90be.fffa.2363.1e28.\n                 8cc7.0208.1a64.39ec.84c8.7814.a1f0.ab72.\n                 78a5.636f.4317.2f60.748f.82ee.5def.b2fc.\n                 682e.6ff3.d6b2.b8a3.5b9c.ca4f.7763.e373.\n                 4ed8.aa4a.e341.8acb.391c.0cb3.c5c9.5a63.\n                 34b0.bcb5.e19b.48a8.2748.774c.df8e.eb99.\n                 1e37.6c08.5141.ab53.19a4.c116.b8d2.d0c8.\n                 106a.a070.32bb.d1b8.f40e.3585.5771.202a.\n                 d699.0624.5565.a910.d192.e819.d6ef.5218.\n                 c76c.51a3.0654.be30.c24b.8b70.d0f8.9791.\n                 a81a.664b.bc42.3001.a2bf.e8a1.4cf1.0364.\n                 9272.2c85.1482.353b.81c2.c92e.47ed.aee6.\n                 766a.0abb.3c77.b2a8.650a.7354.8baf.63de.\n                 5338.0d13.9d95.b3df.4d2c.6dfc.5ac4.2aed.\n                 2e1b.2138.5c26.c926.27b7.0a85.46d2.2ffc.\n                 1429.2967.0a0e.6e70.06ca.6351.e003.826f.\n                 d5a7.9147.930a.a725.c6e0.0bf3.3da8.8fc2.\n                 bf59.7fc7.beef.0ee4.b003.27c8.98fb.213f.\n                 a831.c66d.2db4.3210.983e.5152.ee66.dfab.\n                 76f9.88da.8311.53b5.5cb0.a9dc.bd41.fbd4.\n                 4a74.84aa.6ea6.e483.2de9.2c6f.592b.0275.\n                 240c.a1cc.77ac.9c65.0fc1.9dc6.8b8c.d5b5.\n                 efbe.4786.384f.25e3.e49b.69c1.9ef1.4ad2.\n                 c19b.f174.cf69.2694.9bdc.06a7.25c7.1235.\n                 80de.b1fe.3b16.96b1.72be.5d74.f27b.896f.\n                 550c.7dc3.d5ff.b4e2.2431.85be.4ee4.b28c.\n                 1283.5b01.4570.6fbe.d807.aa98.a303.0242.\n                 ab1c.5ed5.da6d.8118.923f.82a4.af19.4f9b.\n                 59f1.11f1.b605.d019.3956.c25b.f348.b538.\n                 e9b5.dba5.8189.dbbc.b5c0.fbcf.ec4d.3b2f.\n                 7137.4491.23ef.65cd.428a.2f98.d728.ae22\n  =+  ^=  hax  0x5be0.cd19.137e.2179.1f83.d9ab.fb41.bd6b.\n                 9b05.688c.2b3e.6c1f.510e.527f.ade6.82d1.\n                 a54f.f53a.5f1d.36f1.3c6e.f372.fe94.f82b.\n                 bb67.ae85.84ca.a73b.6a09.e667.f3bc.c908\n  =+  i=0\n  |-  ^-  @\n  ?:  =(i lex)\n    (rep 6 (turn (rip 6 hax) net))\n  =+  ^=  wox\n      =+  dux=(cut 10 [i 1] ful)\n      =+  wox=(rep 6 (turn (rip 6 dux) net))\n      =+  j=16\n      |-  ^-  @\n      ?:  =(80 j)\n        wox\n      =+  :*  l=(wac (sub j 15) wox)\n              m=(wac (sub j 2) wox)\n              n=(wac (sub j 16) wox)\n              o=(wac (sub j 7) wox)\n          ==\n      =+  x=:(mix (ror 0 1 l) (ror 0 8 l) (rsh 0 7 l))\n      =+  y=:(mix (ror 0 19 m) (ror 0 61 m) (rsh 0 6 m))\n      =+  z=:(sum n x o y)\n      $(wox (con (lsh 6 j z) wox), j +(j))\n  =+  j=0\n  =+  :*  a=(wac 0 hax)\n          b=(wac 1 hax)\n          c=(wac 2 hax)\n          d=(wac 3 hax)\n          e=(wac 4 hax)\n          f=(wac 5 hax)\n          g=(wac 6 hax)\n          h=(wac 7 hax)\n      ==\n  |-  ^-  @\n  ?:  =(80 j)\n    %=  ^$\n      i  +(i)\n      hax  %+  rep  6\n           :~  (sum a (wac 0 hax))\n               (sum b (wac 1 hax))\n               (sum c (wac 2 hax))\n               (sum d (wac 3 hax))\n               (sum e (wac 4 hax))\n               (sum f (wac 5 hax))\n               (sum g (wac 6 hax))\n               (sum h (wac 7 hax))\n           ==\n    ==\n  =+  l=:(mix (ror 0 28 a) (ror 0 34 a) (ror 0 39 a))   ::  S0\n  =+  m=:(mix (dis a b) (dis a c) (dis b c))            ::  maj\n  =+  n=(sum l m)                                       ::  t2\n  =+  o=:(mix (ror 0 14 e) (ror 0 18 e) (ror 0 41 e))   ::  S1\n  =+  p=(mix (dis e f) (dis (inv e) g))                 ::  ch\n  =+  q=:(sum h o p (wac j kbx) (wac j wox))            ::  t1\n  $(j +(j), a (sum q n), b a, c b, d c, e (sum d q), f e, g f, h g)\n::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "sham"
+    ],
+    "doc": "<h1><code>++sham</code></h1>\n\n<pre><code>++  sham                                                ::  noun hash\n  |=  yux/*  ^-  @uvH  ^-  @\n  ?@  yux\n    (shaf %mash yux)\n  (shaf %sham (jam yux))\n::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "shan"
+    ],
+    "doc": "<h1><code>++shan</code></h1>\n\n<pre><code>++  shan                                                ::  sha-1 (deprecated)\n  |=  ruz/@\n  =+  [few==&gt;(fe .(a 5)) wac=|=({a/@ b/@} (cut 5 [a 1] b))]\n  =+  [sum=sum.few ror=ror.few rol=rol.few net=net.few inv=inv.few]\n  =+  ral=(lsh 0 3 (met 3 ruz))\n  =+  ^=  ful\n      %+  can  0\n      :~  [ral ruz]\n          [8 128]\n          [(mod (sub 960 (mod (add 8 ral) 512)) 512) 0]\n          [64 (~(net fe 6) ral)]\n      ==\n  =+  lex=(met 9 ful)\n  =+  kbx=0xca62.c1d6.8f1b.bcdc.6ed9.eba1.5a82.7999\n  =+  hax=0xc3d2.e1f0.1032.5476.98ba.dcfe.efcd.ab89.6745.2301\n  =+  i=0\n  |-\n  ?:  =(i lex)\n    (rep 5 (flop (rip 5 hax)))\n  =+  ^=  wox\n      =+  dux=(cut 9 [i 1] ful)\n      =+  wox=(rep 5 (turn (rip 5 dux) net))\n      =+  j=16\n      |-  ^-  @\n      ?:  =(80 j)\n        wox\n      =+  :*  l=(wac (sub j 3) wox)\n              m=(wac (sub j 8) wox)\n              n=(wac (sub j 14) wox)\n              o=(wac (sub j 16) wox)\n          ==\n      =+  z=(rol 0 1 :(mix l m n o))\n      $(wox (con (lsh 5 j z) wox), j +(j))\n  =+  j=0\n  =+  :*  a=(wac 0 hax)\n          b=(wac 1 hax)\n          c=(wac 2 hax)\n          d=(wac 3 hax)\n          e=(wac 4 hax)\n      ==\n  |-  ^-  @\n  ?:  =(80 j)\n    %=  ^$\n      i  +(i)\n      hax  %+  rep  5\n           :~\n               (sum a (wac 0 hax))\n               (sum b (wac 1 hax))\n               (sum c (wac 2 hax))\n               (sum d (wac 3 hax))\n               (sum e (wac 4 hax))\n           ==\n    ==\n  =+  fx=(con (dis b c) (dis (not 5 1 b) d))\n  =+  fy=:(mix b c d)\n  =+  fz=:(con (dis b c) (dis b d) (dis c d))\n  =+  ^=  tem\n      ?:  &amp;((gte j 0) (lte j 19))\n        :(sum (rol 0 5 a) fx e (wac 0 kbx) (wac j wox))\n      ?:  &amp;((gte j 20) (lte j 39))\n        :(sum (rol 0 5 a) fy e (wac 1 kbx) (wac j wox))\n      ?:  &amp;((gte j 40) (lte j 59))\n        :(sum (rol 0 5 a) fz e (wac 2 kbx) (wac j wox))\n      :(sum (rol 0 5 a) fy e (wac 3 kbx) (wac j wox))\n  $(j +(j), a tem, b a, c (rol 0 30 b), d c, e d)\n::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "shas"
+    ],
+    "doc": "<h1><code>++shas</code></h1>\n\n<pre><code>++  shas                                                ::  salted hash\n  |=  [sal/@ ruz/@]\n  (shax (mix sal (shax ruz)))\n::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "shaw"
+    ],
+    "doc": "<h1><code>++shaw</code></h1>\n\n<pre><code>++  shaw                                                ::  hash to nbits\n  |=  [sal/@ len/@ ruz/@]\n  (~(raw og (shas sal (mix len ruz))) len)\n::\n</code></pre>"
+  },
+  {
+    "keys": [
+      "shax"
+    ],
+    "doc": "<h1><code>++shax</code></h1>\n\n<p>++  shax                                                ::  sha-256\n  ~/  %shax\n  |=  ruz/@  ^-  @\n  (shay [(met 3 ruz) ruz])\n::</p>\n\n<p>XX document</p>"
+  },
+
+  {
+    "keys": [
+      "aesc"
+    ],
+    "doc": "<h1><code>++aesc</code></h1>\n\n<pre><code>++  aesc                                                ::  AES-256\n  ~%  %aesc  +  ~\n  |%\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "en"
+    ],
+    "doc": "<h1><code>++en</code></h1>\n\n<pre><code>  ++  en                                                ::  ECB enc\n    ~/  %en\n    |=  [a/@I b/@H]  ^-  @uxH\n    =+  ahem\n    (be &amp; (ex a) b)\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "de"
+    ],
+    "doc": "<h1><code>++de</code></h1>\n\n<pre><code>  ++  de                                                ::  ECB dec\n    ~/  %de\n    |=  [a/@I b/@H]  ^-  @uxH\n    =+  ahem\n    (be | (ix (ex a)) b)\n  --\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ahem"
+    ],
+    "doc": "<h1><code>++ahem</code></h1>\n\n<pre><code>  =&gt;\n    =+  =+  [gr=(ga 8 0x11b 3) few==&gt;(fe .(a 5))]\n        =+  [pro=pro.gr dif=dif.gr pow=pow.gr ror=ror.few]\n        [pro=pro dif=dif pow=pow ror=ror nnk=8 nnb=4 nnr=14]\n    =&gt;  |%\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "cipa"
+    ],
+    "doc": "<h1><code>++cipa</code></h1>\n\n<pre><code>        ++  cipa                                        ::  AES params\n          $_  ^?  |%\n</code></pre>\n\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "co"
+    ],
+    "doc": "<h1><code>++co</code></h1>\n\n<pre><code>      ++  co  *{p/@ q/@ r/@ s/@}                    ::  col coefs\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ix"
+    ],
+    "doc": "<h1><code>++ix</code></h1>\n\n<pre><code>      ++  ix  |~(a/@ *@)                            ::  key index\n</code></pre>\n\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ro"
+    ],
+    "doc": "<h1><code>++ro</code></h1>\n\n<pre><code>      ++  ro  *{p/@ q/@ r/@ s/@}                    ::  row shifts\n</code></pre>\n\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "su"
+    ],
+    "doc": "<h1><code>++su</code></h1>\n\n<pre><code>      ++  su  *@                                    ::  s-box\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "pen"
+    ],
+    "doc": "<h1><code>++pen</code></h1>\n\n<pre><code>    ++  pen                                             ::  encrypt\n      ^-  cipa\n      |%\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "co"
+    ],
+    "doc": "<h1><code>++co</code></h1>\n\n<pre><code>  ++  co  [0x2 0x3 1 1]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ix"
+    ],
+    "doc": "<h1><code>++ix</code></h1>\n\n<pre><code>      ++  ix  |~(a/@ *@)                            ::  key index\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ro"
+    ],
+    "doc": "<h1><code>++ro</code></h1>\n\n<pre><code>      ++  ro  *{p/@ q/@ r/@ s/@}                    ::  row shifts\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "su"
+    ],
+    "doc": "<h1><code>++su</code></h1>\n\n<pre><code>      ++  su  0x7d0c.2155.6314.69e1.26d6.77ba.7e04.2b17.\n                6199.5383.3cbb.ebc8.b0f5.2aae.4d3b.e0a0.\n                ef9c.c993.9f7a.e52d.0d4a.b519.a97f.5160.\n                5fec.8027.5910.12b1.31c7.0788.33a8.dd1f.\n                f45a.cd78.fec0.db9a.2079.d2c6.4b3e.56fc.\n                1bbe.18aa.0e62.b76f.89c5.291d.711a.f147.\n                6edf.751c.e837.f9e2.8535.ade7.2274.ac96.\n                73e6.b4f0.cecf.f297.eadc.674f.4111.913a.\n                6b8a.1301.03bd.afc1.020f.3fca.8f1e.2cd0.\n                0645.b3b8.0558.e4f7.0ad3.bc8c.00ab.d890.\n                849d.8da7.5746.155e.dab9.edfd.5048.706c.\n                92b6.655d.cc5c.a4d4.1698.6886.64f6.f872.\n                25d1.8b6d.49a2.5b76.b224.d928.66a1.2e08.\n                4ec3.fa42.0b95.4cee.3d23.c2a6.3294.7b54.\n                cbe9.dec4.4443.8e34.87ff.2f9b.8239.e37c.\n                fbd7.f381.9ea3.40bf.38a5.3630.d56a.0952\n      --\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "pin"
+    ],
+    "doc": "<h1><code>++pin</code></h1>\n\n<pre><code>    ++  pin                                             :: decrypt\n      ^-  cipa\n      |%\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "co"
+    ],
+    "doc": "<h1><code>++co</code></h1>\n\n<pre><code>      ++  co  [0xe 0xb 0xd 0x9]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ix"
+    ],
+    "doc": "<h1><code>++ix</code></h1>\n\n<pre><code>  ++  ix                                                ::  key expand, inv\n    |=  a=@  ^-  @\n    =+  [i=1 j=_@ b=_@ c=co:pin]\n    |-\n    ?:  =(nnr i)\n      a\n    =&gt;  .(b (cut 7 [i 1] a))\n    =&gt;  .(b (rep 5 (mcol (pode 5 4 b) c)))\n    =&gt;  .(j (sub nnr i))\n    %=    $\n        i  +(i)\n        a\n      %+  can  7\n      :~  [i (cut 7 [0 i] a)]\n          [1 b]\n          [j (cut 7 [+(i) j] a)]\n      ==\n    ==\n  --\n::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ro"
+    ],
+    "doc": "<h1><code>++ro</code></h1>\n\n<pre><code>      ++  ro  [0 3 2 1]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "su"
+    ],
+    "doc": "<h1><code>++su</code></h1>\n\n<pre><code>      ++  su  0x7d0c.2155.6314.69e1.26d6.77ba.7e04.2b17.\n                6199.5383.3cbb.ebc8.b0f5.2aae.4d3b.e0a0.\n                ef9c.c993.9f7a.e52d.0d4a.b519.a97f.5160.\n                5fec.8027.5910.12b1.31c7.0788.33a8.dd1f.\n                f45a.cd78.fec0.db9a.2079.d2c6.4b3e.56fc.\n                1bbe.18aa.0e62.b76f.89c5.291d.711a.f147.\n                6edf.751c.e837.f9e2.8535.ade7.2274.ac96.\n                73e6.b4f0.cecf.f297.eadc.674f.4111.913a.\n                6b8a.1301.03bd.afc1.020f.3fca.8f1e.2cd0.\n                0645.b3b8.0558.e4f7.0ad3.bc8c.00ab.d890.\n                849d.8da7.5746.155e.dab9.edfd.5048.706c.\n                92b6.655d.cc5c.a4d4.1698.6886.64f6.f872.\n                25d1.8b6d.49a2.5b76.b224.d928.66a1.2e08.\n                4ec3.fa42.0b95.4cee.3d23.c2a6.3294.7b54.\n                cbe9.dec4.4443.8e34.87ff.2f9b.8239.e37c.\n                fbd7.f381.9ea3.40bf.38a5.3630.d56a.0952\n      --\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "mcol"
+    ],
+    "doc": "<h1><code>++mcol</code></h1>\n\n<pre><code>    ++  mcol\n      |=  [a=(list ,@) b=[p=@ q=@ r=@ s=@]]  ^-  (list ,@)\n      =+  c=[p=_@ q=_@ r=_@ s=_@]\n      |-  ^-  (list ,@)\n      ?~  a  ~\n      =&gt;  .(p.c (cut 3 [0 1] i.a))\n      =&gt;  .(q.c (cut 3 [1 1] i.a))\n      =&gt;  .(r.c (cut 3 [2 1] i.a))\n      =&gt;  .(s.c (cut 3 [3 1] i.a))\n      :_  $(a t.a)\n      %+  rep  3\n      %+  turn\n        %-  limo\n        :~  [[p.c p.b] [q.c q.b] [r.c r.b] [s.c s.b]]\n            [[p.c s.b] [q.c p.b] [r.c q.b] [s.c r.b]]\n            [[p.c r.b] [q.c s.b] [r.c p.b] [s.c q.b]]\n            [[p.c q.b] [q.c r.b] [r.c s.b] [s.c p.b]]\n        ==\n      |=  [a=[@ @] b=[@ @] c=[@ @] d=[@ @]]\n      :(dif (pro a) (pro b) (pro c) (pro d))\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "pode"
+    ],
+    "doc": "<h1><code>++pode</code></h1>\n\n<pre><code>    ++  pode                                            ::  explode to block\n      |=  [a=bloq b=@ c=@]  ^-  (list ,@)\n      =+  d=(rip a c)\n      =+  m=(met a c)\n      |-\n      ?:  =(m b)\n        d\n      $(m +(m), d (weld d (limo [0 ~])))\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "sube"
+    ],
+    "doc": "<h1><code>++sube</code></h1>\n\n<pre><code>    ++  sube                                            ::  s-box word\n      |=  [a=@ b=@]  ^-  @\n      (rep 3 (turn (pode 3 4 a) |=(c=@ (cut 3 [c 1] b))))\n    --\n  |%\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "be"
+    ],
+    "doc": "<h1><code>++be</code></h1>\n\n<pre><code>  ++  be                                                ::  block cipher\n    |=  [a=? b=@ c=@H]  ^-  @uxH\n    ~|  %be-aesc\n    =&gt;  %=    .\n            +\n          =&gt;  +\n          |%\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ankh"
+    ],
+    "doc": "<h1><code>++ankh</code></h1>\n\n<pre><code>          ++  ankh\n            |=  [a=cipa b=@ c=@]\n            (pode 5 nnb (cut 5 [(mul (ix.a b) nnb) nnb] c))\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "sark"
+    ],
+    "doc": "<h1><code>++sark</code></h1>\n\n<pre><code>          ++  sark\n            |=  [c=(list ,@) d=(list ,@)]  ^-  (list ,@)\n            ?~  c  ~\n            ?~  d  !!\n            [(mix i.c i.d) $(c t.c, d t.d)]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "srow"
+    ],
+    "doc": "<h1><code>++srow</code></h1>\n\n<pre><code>          ++  srow\n            |=  [a=cipa b=(list ,@)]  ^-  (list ,@)\n            =+  [c=0 d=~ e=ro.a]\n            |-\n            ?:  =(c nnb)\n              d\n            :_  $(c +(c))\n            %+  rep  3\n            %+  turn\n              (limo [0 p.e] [1 q.e] [2 r.e] [3 s.e] ~)\n            |=  [f=@ g=@]\n            (cut 3 [f 1] (snag (mod (add g c) nnb) b))\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "subs"
+    ],
+    "doc": "<h1><code>++subs</code></h1>\n\n<pre><code>          ++  subs\n            |=  [a=cipa b=(list ,@)]  ^-  (list ,@)\n            ?~  b  ~\n            [(sube i.b su.a) $(b t.b)]\n          --\n        ==\n    =+  [d=?:(a pen pin) e=(pode 5 nnb c) f=1]\n    =&gt;  .(e (sark e (ankh d 0 b)))\n    |-\n    ?.  =(nnr f)\n      =&gt;  .(e (subs d e))\n      =&gt;  .(e (srow d e))\n      =&gt;  .(e (mcol e co.d))\n      =&gt;  .(e (sark e (ankh d f b)))\n      $(f +(f))\n    =&gt;  .(e (subs d e))\n    =&gt;  .(e (srow d e))\n    =&gt;  .(e (sark e (ankh d nnr b)))\n    (rep 5 e)\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ex"
+    ],
+    "doc": "<h1><code>++ex</code></h1>\n\n<pre><code>  ++  ex                                                ::  key expand\n    |=  a=@I  ^-  @\n    =+  [b=a c=0 d=su:pen i=nnk]\n    |-\n    ?:  =(i (mul nnb +(nnr)))\n      b\n    =&gt;  .(c (cut 5 [(dec i) 1] b))\n    =&gt;  ?:  =(0 (mod i nnk))\n          =&gt;  .(c (ror 3 1 c))\n          =&gt;  .(c (sube c d))\n          .(c (mix c (pow (dec (div i nnk)) 2)))\n        ?:  &amp;((gth nnk 6) =(4 (mod i nnk)))\n          .(c (sube c d))\n        .\n    =&gt;  .(c (mix c (cut 5 [(sub i nnk) 1] b)))\n    =&gt;  .(b (can 5 [i b] [1 c] ~))\n    $(i +(i))\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ix"
+    ],
+    "doc": "<h1><code>++ix</code></h1>\n\n<pre><code>  ++  ix                                                ::  key expand, inv\n    |=  a=@  ^-  @\n    =+  [i=1 j=_@ b=_@ c=co:pin]\n    |-\n    ?:  =(nnr i)\n      a\n    =&gt;  .(b (cut 7 [i 1] a))\n    =&gt;  .(b (rep 5 (mcol (pode 5 4 b) c)))\n    =&gt;  .(j (sub nnr i))\n    %=    $\n        i  +(i)\n        a\n      %+  can  7\n      :~  [i (cut 7 [0 i] a)]\n          [1 b]\n          [j (cut 7 [+(i) j] a)]\n      ==\n    ==\n  --\n::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "curt"
+    ],
+    "doc": "<h1><code>++curt</code></h1>\n\n<pre><code>++  curt                                                ::  curve25519\n  |=  [a=@ b=@]\n  =&gt;  %=    .\n          +\n        =&gt;  +\n        =+  =+  [p=486.662 q=(sub (bex 255) 19)]\n            =+  fq=~(. fo q)\n            [p=p q=q fq=fq]\n        |%\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "cla"
+    ],
+    "doc": "<h1><code>++cla</code></h1>\n\n<pre><code>        ++  cla\n          |=  raw=@\n          =+  low=(dis 248 (cut 3 [0 1] raw))\n          =+  hih=(con 64 (dis 127 (cut 3 [31 1] raw)))\n          =+  mid=(cut 3 [1 30] raw)\n          (can 3 [[1 low] [30 mid] [1 hih] ~])\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "sqr"
+    ],
+    "doc": "<h1><code>++sqr</code></h1>\n\n<pre><code>        ++  sqr  |=(a=@ (mul a a))\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "inv"
+    ],
+    "doc": "<h1><code>++inv</code></h1>\n\n<pre><code>        ++  inv  |=(a=@ (~(exp fo q) (sub q 2) a))\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "cad"
+    ],
+    "doc": "<h1><code>++cad</code></h1>\n\n<pre><code>        ++  cad\n          |=  [n=[x=@ z=@] m=[x=@ z=@] d=[x=@ z=@]]\n          =+  ^=  xx\n              ;:  mul  4  z.d\n                %-  sqr  %-  abs:si\n                %+  dif:si\n                  (sun:si (mul x.m x.n))\n                (sun:si (mul z.m z.n))\n              ==\n          =+  ^=  zz\n              ;:  mul  4  x.d\n                %-  sqr  %-  abs:si\n                %+  dif:si\n                  (sun:si (mul x.m z.n))\n                (sun:si (mul z.m x.n))\n              ==\n          [(sit.fq xx) (sit.fq zz)]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "cub"
+    ],
+    "doc": "<h1><code>++cub</code></h1>\n\n<pre><code>        ++  cub\n          |=  [x=@ z=@]\n          =+  ^=  xx\n              %+  mul\n                %-  sqr  %-  abs:si\n                (dif:si (sun:si x) (sun:si z))\n              (sqr (add x z))\n          =+  ^=  zz\n              ;:  mul  4  x  z\n                :(add (sqr x) :(mul p x z) (sqr z))\n              ==\n          [(sit.fq xx) (sit.fq zz)]\n        --\n      ==\n  =+  one=[b 1]\n  =+  i=253\n  =+  r=one\n  =+  s=(cub one)\n  |-\n  ?:  =(i 0)\n    =+  x=(cub r)\n    (sit.fq (mul -.x (inv +.x)))\n  =+  m=(rsh 0 i a)\n  ?:  =(0 (mod m 2))\n     $(i (dec i), s (cad r s one), r (cub r))\n  $(i (dec i), r (cad r s one), s (cub s))\n::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ed"
+    ],
+    "doc": "<h1><code>++ed</code></h1>\n\n<pre><code>++  ed                                                  ::  ed25519\n  =&gt;\n    =+  =+  [b=256 q=(sub (bex 255) 19)]\n        =+  fq=~(. fo q)\n        =+  ^=  l\n             %+  add\n               (bex 252)\n             27.742.317.777.372.353.535.851.937.790.883.648.493\n        =+  d=(dif.fq 0 (fra.fq 121.665 121.666))\n        =+  ii=(exp.fq (div (dec q) 4) 2)\n        [b=b q=q fq=fq l=l d=d ii=ii]\n    ~%  %coed  +&gt;  ~\n    |%\n</code></pre>"
+  },
+  {
+    "keys": [
+      "norm"
+    ],
+    "doc": "<h1><code>++norm</code></h1>\n\n<pre><code>    ++  norm  |=(x=@ ?:(=(0 (mod x 2)) x (sub q x)))\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "xrec"
+    ],
+    "doc": "<h1><code>++xrec</code></h1>\n\n<pre><code>    ++  xrec                                            ::  recover x-coord\n      |=  y=@  ^-  @\n      =+  ^=  xx\n          %+  mul  (dif.fq (mul y y) 1)\n                   (inv.fq +(:(mul d y y)))\n      =+  x=(exp.fq (div (add 3 q) 8) xx)\n      ?:  !=(0 (dif.fq (mul x x) (sit.fq xx)))\n        (norm (pro.fq x ii))\n      (norm x)\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ward"
+    ],
+    "doc": "<h1><code>++ward</code></h1>\n\n<pre><code>    ++  ward                                            ::  edwards multiply\n      |=  [pp=[@ @] qq=[@ @]]  ^-  [@ @]\n      =+  dp=:(pro.fq d -.pp -.qq +.pp +.qq)\n      =+  ^=  xt\n          %+  pro.fq\n            %+  sum.fq\n              (pro.fq -.pp +.qq)\n            (pro.fq -.qq +.pp)\n          (inv.fq (sum.fq 1 dp))\n      =+  ^=  yt\n          %+  pro.fq\n            %+  sum.fq\n              (pro.fq +.pp +.qq)\n            (pro.fq -.pp -.qq)\n          (inv.fq (dif.fq 1 dp))\n      [xt yt]\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "scam"
+    ],
+    "doc": "<h1><code>++scam</code></h1>\n\n<pre><code>    ++  scam                                            ::  scalar multiply\n      |=  [pp=[@ @] e=@]  ^-  [@ @]\n      ?:  =(0 e)\n        [0 1]\n      =+  qq=$(e (div e 2))\n      =&gt;  .(qq (ward qq qq))\n      ?:  =(1 (dis 1 e))\n        (ward qq pp)\n      qq\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "etch"
+    ],
+    "doc": "<h1><code>++etch</code></h1>\n\n<pre><code>    ++  etch                                            ::  encode point\n      |=  pp=[@ @]  ^-  @\n      (can 0 ~[[(sub b 1) +.pp] [1 (dis 1 -.pp)]])\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "curv"
+    ],
+    "doc": "<h1><code>++curv</code></h1>\n\n<pre><code>    ++  curv                                            ::  point on curve?\n      |=  [x=@ y=@]  ^-  ?\n      .=  0\n          %+  dif.fq\n            %+  sum.fq\n              (pro.fq (sub q (sit.fq x)) x)\n            (pro.fq y y)\n          (sum.fq 1 :(pro.fq d x x y y))\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "deco"
+    ],
+    "doc": "<h1><code>++deco</code></h1>\n\n<pre><code>    ++  deco                                            ::  decode point\n      |=  s=@  ^-  (unit ,[@ @])\n      =+  y=(cut 0 [0 (dec b)] s)\n      =+  si=(cut 0 [(dec b) 1] s)\n      =+  x=(xrec y)\n      =&gt;  .(x ?:(!=(si (dis 1 x)) (sub q x) x))\n      =+  pp=[x y]\n      ?.  (curv pp)\n        ~\n      [~ pp]\n    ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "bb"
+    ],
+    "doc": "<h1><code>++bb</code></h1>\n\n<pre><code>    ++  bb\n      =+  bby=(pro.fq 4 (inv.fq 5))\n    [(xrec bby) bby]\n    ::\n    --\n  ~%  %ed  +  ~\n  |%\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "puck"
+    ],
+    "doc": "<h1><code>++puck</code></h1>\n\n<pre><code>  ++  puck                                                ::  public key\n    ~/  %puck\n    |=  sk=@I  ^-  @\n    ?:  (gth (met 3 sk) 32)  !!\n    =+  h=(shal (rsh 0 3 b) sk)\n    =+  ^=  a\n        %+  add\n          (bex (sub b 2))\n        (lsh 0 3 (cut 0 [3 (sub b 5)] h))\n    =+  aa=(scam bb a)\n    (etch aa)\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "suck"
+    ],
+    "doc": "<h1><code>++suck</code></h1>\n\n<pre><code>  ++  suck                                                ::  keypair from seed\n    |=  se=@I  ^-  @uJ\n    =+  pu=(puck se)\n    (can 0 ~[[b se] [b pu]])\n  ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "sign"
+    ],
+    "doc": "<h1><code>++sign</code></h1>\n\n<pre><code>  ++  sign                                                ::  certify\n    ~/  %sign\n    |=  [m=@ se=@]  ^-  @\n    =+  sk=(suck se)\n    =+  pk=(cut 0 [b b] sk)\n    =+  h=(shal (rsh 0 3 b) sk)\n    =+  ^=  a\n        %+  add\n          (bex (sub b 2))\n        (lsh 0 3 (cut 0 [3 (sub b 5)] h))\n    =+  ^=  r\n        =+  hm=(cut 0 [b b] h)\n        =+  ^=  i\n            %+  can  0\n            :~  [b hm]\n                [(met 0 m) m]\n            ==\n        (shaz i)\n    =+  rr=(scam bb r)\n    =+  ^=  ss\n        =+  er=(etch rr)\n        =+  ^=  ha\n            %+  can  0\n            :~  [b er]\n                [b pk]\n                [(met 0 m) m]\n            ==\n        (~(sit fo l) (add r (mul (shaz ha) a)))\n    (can 0 ~[[b (etch rr)] [b ss]])\n  ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+
+  {
+    "keys": [
+      "ob"
+    ],
+    "doc": "<h1><code>++ob</code></h1>\n\n<p>Reversible scrambling core, v2</p>\n\n<pre><code>++  ob\n  |%\n</code></pre>\n\n<p>A core for performing reversible scrambling operations for the <code>@p</code> phonetic base.</p>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "feen"
+    ],
+    "doc": "<h1><code>++feen</code></h1>\n\n<p>Conceal structure, v2</p>\n\n<p>Randomly permutes atoms that fit into 17 to 32 bits into one another. If the\natom fits into 33 to 64 bits, does the same permutation on the low 32 bits\nonly. Otherwise, passes the atom through unchanged.</p>\n\n<h2>Accepts</h2>\n\n<p>An atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  feen                                              ::  conceal structure v2\n    |=  pyn/@  ^-  @\n    ?:  &amp;((gte pyn 0x1.0000) (lte pyn 0xffff.ffff))\n      (add 0x1.0000 (fice (sub pyn 0x1.0000)))\n    ?:  &amp;((gte pyn 0x1.0000.0000) (lte pyn 0xffff.ffff.ffff.ffff))\n      =+  lo=(dis pyn 0xffff.ffff)\n      =+  hi=(dis pyn 0xffff.ffff.0000.0000)\n      %+  con  hi\n      (add 0x1.0000 (fice (sub lo 0x1.0000)))\n    pyn\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>XX</p>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "fend"
+    ],
+    "doc": "<h1><code>++fend</code></h1>\n\n<p>XX</p>\n\n<p>Randomly permutes atoms that fit into 17 to 32 bits into one another, and\nrandomly permutes the low 32 bits of atoms that fit into 33 to 64 bits;\notherwise, passes the atom through unchanged. The permutation is the inverse of\nthe one applied by <code>++feen</code>.</p>\n\n<h2>Accepts</h2>\n\n<p>An atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  fend                                              ::  restore structure v2\n    |=  cry/@  ^-  @\n    ?:  &amp;((gte cry 0x1.0000) (lte cry 0xffff.ffff))\n      (add 0x1.0000 (teil (sub cry 0x1.0000)))\n    ?:  &amp;((gte cry 0x1.0000.0000) (lte cry 0xffff.ffff.ffff.ffff))\n      =+  lo=(dis cry 0xffff.ffff)\n      =+  hi=(dis cry 0xffff.ffff.0000.0000)\n      %+  con  hi\n      (add 0x1.0000 (teil (sub lo 0x1.0000)))\n    cry\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "fice"
+    ],
+    "doc": "<h1><code>++fice</code></h1>\n\n<p>XX</p>\n\n\n<h2>Accepts</h2>\n\n<p>An atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  fice                                              ::  adapted from\n        |=  nor/@                                           ::  black and rogaway\n        ^-  @                                               ::  \"ciphers with\n        =+  ^=  sel                                         ::   arbitrary finite\n        %+  rynd  2                                         ::   domains\", 2002\n        %+  rynd  1\n        %+  rynd  0\n        [(mod nor 65.535) (div nor 65.535)]\n        (add (mul 65.535 -.sel) +.sel)\n      ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "teil"
+    ],
+    "doc": "<h1><code>++teil</code></h1>\n\n<p>XX</p>\n\n<p>Applies the reverse of the Feistel-like cipher applied by <code>++fice</code>. Unlike\na conventional Feistel cipher that is its own inverse if keys are used in\nreverse order, this Feistel-like cipher uses two moduli that must be swapped\nwhen applying the reverse transformation.</p>\n\n<h2>Accepts</h2>\n\n<p>An atom.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  teil                                              ::  reverse ++fice\n    |=  vip/@\n    ^-  @\n    =+  ^=  sel\n    %+  rund  0\n    %+  rund  1\n    %+  rund  2\n    [(mod vip 65.535) (div vip 65.535)]\n    (add (mul 65.535 -.sel) +.sel)\n  ::\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rynd"
+    ],
+    "doc": "<h1><code>++rynd</code></h1>\n\n<p>XX</p>\n\n<p>A single round of the Feistel-like cipher <code>++fice</code>. AES (<code>++aesc</code>) is\nused as the round function.</p>\n\n<h2>Accepts</h2>\n\n<p>A cell of three atoms, <code>n</code>, <code>l</code>, and <code>r</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A cell of two atoms.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  rynd                                              ::  feistel round\n  |=  [n/@ l/@ r/@]\n  ^-  [@ @]\n  :-  r\n  ?~  (mod n 2)\n    (~(sum fo 65.535) l (en:aesc (snag n raku) r))\n  (~(sum fo 65.536) l (en:aesc (snag n raku) r))\n</code></pre>\n\n<h2>Examples</h2>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rund"
+    ],
+    "doc": "<h1><code>++rund</code></h1>\n\n<p>XX</p>\n\n<p>A single round of the Feistel-like reverse cipher <code>++teil</code>.</p>\n\n<h2>Accepts</h2>\n\n<p>A cell of three atoms, <code>n</code>, <code>l</code>, and <code>r</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A cell of two atoms.</p>\n\n<h2>Source</h2>\n\n<p>  ++  rund                                              ::  reverse round</p>\n<pre><code>|=  {n/@ l/@ r/@}\n^-  {@ @}\n:-  r\n?~  (mod n 2)\n  (~(dif fo 65.535) l (en:aesc (snag n raku) r))\n(~(dif fo 65.536) l (en:aesc (snag n raku) r))\n</code></pre>\n\n<h2>Examples</h2>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "raku"
+    ],
+    "doc": "<h1><code>++raku</code></h1>\n\n<p>XX</p>\n\n\n<h2>Accepts</h2>\n\n<p>A list of atoms of odor <code>@ux</code> (hexadecimal).</p>\n\n<h2>Produces</h2>\n\n<p>Arbitrary keys for use with <code>++aesc</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  raku\n  ^-  (list ,@ux)\n  :~  0x15f6.25e3.083a.eb3e.7a55.d4db.fb99.32a3.\n        43af.2750.219e.8a24.e5f8.fac3.6c36.f968\n      0xf2ff.24fe.54d0.1abd.4b2a.d8aa.4402.8e88.\n        e82f.19ec.948d.b1bb.ed2e.f791.83a3.8133\n      0xa3d8.6a7b.400e.9e91.187d.91a7.6942.f34a.\n        6f5f.ab8e.88b9.c089.b2dc.95a6.aed5.e3a4\n  ==\n</code></pre>\n\n<h2>Examples</h2>"
+  },
+  {
+    "keys": [
+      "un"
+    ],
+    "doc": "<h1><code>++un</code></h1>\n\n<p>Reversible scrambling core</p>\n\n<pre><code>++  un                                                  ::  =(x (wred (wren x)))\n  |%\n</code></pre>\n\n<p>A core that contains arms that perform reversible scrambling operations.\nUsed in the <code>@p</code> phonetic base.</p>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "wren"
+    ],
+    "doc": "<h1><code>++wren</code></h1>\n\n<p>Conceal structure</p>\n\n<p>Scrambles a bytestring <code>pyn</code> by adding the current position to each\nbyte, looking it up in an s-box, and then performing the XOR operation\non the result, pushing it forward. Produces an atom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>pyn</code> is an atom.</p>\n\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  wren                                              ::  conceal structure\n    |=  pyn/@  ^-  @\n    =+  len=(met 3 pyn)\n    ?:  =(0 len)\n      0\n    =&gt;  .(len (dec len))\n    =+  mig=(zaft (xafo len (cut 3 [len 1] pyn)))\n    %+  can  3\n    %-  flop  ^-  (list {@ @})\n    :-  [1 mig]\n    |-  ^-  (list {@ @})\n    ?:  =(0 len)\n      ~\n    =&gt;  .(len (dec len))\n    =+  mog=(zyft :(mix mig (end 3 1 len) (cut 3 [len 1] pyn)))\n    [[1 mog] $(mig mog)]\n  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ux`(wren:un 'testing')\n0x30.bf6a.b9fe.7d8f\n&gt; `@ux`'testing'\n0x67.6e69.7473.6574\n&gt; `@da`(wred:un (wren:un ~2001.2.5))\n~2001.2.5\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "wred"
+    ],
+    "doc": "<h1><code>++wred</code></h1>\n\n<p>Restore structure</p>\n\n<p>Unscrambles a bytestring <code>cry</code> by subtracting the current position from\neach byte, looking it up in an s-box, and performing the XOR operation\non the result, pushing it forward. Produces an atom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>cry</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  wred                                              ::  restore structure\n    |=  cry/@  ^-  @\n    =+  len=(met 3 cry)\n    ?:  =(0 len)\n      0\n    =&gt;  .(len (dec len))\n    =+  mig=(cut 3 [len 1] cry)\n    %+  can  3\n    %-  flop  ^-  (list {@ @})\n    :-  [1 (xaro len (zart mig))]\n    |-  ^-  (list {@ @})\n    ?:  =(0 len)\n      ~\n    =&gt;  .(len (dec len))\n    =+  mog=(cut 3 [len 1] cry)\n    [[1 :(mix mig (end 3 1 len) (zyrt mog))] $(mig mog)]\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (wred:un 0x30.bf6a.b9fe.7d8f)\n29.113.321.805.538.676\n&gt; `@t`(wred:un 0x30.bf6a.b9fe.7d8f)\n'testing'\n&gt; (wred:un (wren:un 200.038.426))\n200.038.426\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "xafo"
+    ],
+    "doc": "<h1><code>++xafo</code></h1>\n\n<p>Add modulo 255</p>\n\n<p>Produces the sum of two atoms modulo 255, encoded as a nonzero byte.</p>\n\n<h2>Accepts</h2>\n\n<p>A cell of two atoms, <code>a</code> and <code>b</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  xafo  |=([a/@ b/@] +((mod (add (dec b) a) 255)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (xafo:un 5 6)\n11\n&gt; (xafo:un 256 20)\n21\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "xaro"
+    ],
+    "doc": "<h1><code>++xaro</code></h1>\n\n<p>Subtract modulo 255</p>\n\n<p>Produces the difference between two atoms modulo 255, encoded as a\nnonzero byte.</p>\n\n<h2>Accepts</h2>\n\n<p>A cell of two atoms, <code>a</code> and <code>b</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  xaro  |=([a/@ b/@] +((mod (add (dec b) (sub 255 (mod a 255))) 255)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (xaro:un 17 57)\n40\n&gt; (xaro:un 265 12)\n2\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "zaft"
+    ],
+    "doc": "<h1><code>++zaft</code></h1>\n\n<p>Look up in 255 sub box</p>\n\n<p>The inverse of <code>++zart</code>. Looks up a nonzero byte <code>a</code>in a substiution\nbox with 255 values, producing a unique nonzero byte.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom of one byte in length.</p>\n\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  zaft                                              ::  forward 255-sbox\n    |=  a/@D\n    =+  ^=  b\n        0xcc.75bc.86c8.2fb1.9a42.f0b3.79a0.92ca.21f6.1e41.cde5.fcc0.\n        7e85.51ae.1005.c72d.1246.07e8.7c64.a914.8d69.d9f4.59c2.8038.\n        1f4a.dca2.6fdf.66f9.f561.a12e.5a16.f7b0.a39f.364e.cb70.7318.\n        1de1.ad31.63d1.abd4.db68.6a33.134d.a760.edee.5434.493a.e323.\n        930d.8f3d.3562.bb81.0b24.43cf.bea5.a6eb.52b4.0229.06b2.6704.\n        78c9.45ec.d75e.58af.c577.b7b9.c40e.017d.90c3.87f8.96fa.1153.\n        0372.7f30.1c32.ac83.ff17.c6e4.d36d.6b55.e2ce.8c71.8a5b.b6f3.\n        9d4b.eab5.8b3c.e7f2.a8fe.9574.5de0.bf20.3f15.9784.9939.5f9c.\n        e609.564f.d8a4.b825.9819.94aa.2c08.8e4c.9b22.477a.2840.3ed6.\n        3750.6ef1.44dd.89ef.6576.d00a.fbda.9ed2.3b6c.7b0c.bde9.2ade.\n        5c88.c182.481a.1b0f.2bfd.d591.2726.57ba\n    (cut 3 [(dec a) 1] b)\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (zaft:un 0x12)\n42\n&gt; (zaft:un 0xff)\n204\n&gt; (zaft:un 0x0)\n! decrement-underflow\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "zart"
+    ],
+    "doc": "<h1><code>++zart</code></h1>\n\n<p>Reverse look up in 255 sub box</p>\n\n<p>The inverse of <code>++zaft</code>. Looks up the index of a nonzero byte <code>a</code> in\nthe substitution box with 255 values, producing a unique nonzero byte.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom of one byte in length.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  zart                                              ::  reverse 255-sbox\n    |=  a/@D\n    =+  ^=  b\n        0x68.4f07.ea1c.73c9.75c2.efc8.d559.5125.f621.a7a8.8591.5613.\n        dd52.40eb.65a2.60b7.4bcb.1123.ceb0.1bd6.3c84.2906.b164.19b3.\n        1e95.5fec.ffbc.f187.fbe2.6680.7c77.d30e.e94a.9414.fd9a.017d.\n        3a7e.5a55.8ff5.8bf9.c181.e5b6.6ab2.35da.50aa.9293.3bc0.cdc6.\n        f3bf.1a58.4130.f844.3846.744e.36a0.f205.789e.32d8.5e54.5c22.\n        0f76.fce7.4569.0d99.d26e.e879.dc16.2df4.887f.1ffe.4dba.6f5d.\n        bbcc.2663.1762.aed7.af8a.ca20.dbb4.9bc7.a942.834c.105b.c4d4.\n        8202.3e61.a671.90e6.273d.bdab.3157.cfa4.0c2e.df86.2496.f7ed.\n        2b48.2a9d.5318.a343.d128.be9c.a5ad.6bb5.6dfa.c5e1.3408.128d.\n        2c04.0339.97a1.2ff0.49d0.eeb8.6c0a.0b37.b967.c347.d9ac.e072.\n        e409.7b9f.1598.1d3f.33de.8ce3.8970.8e7a\n    (cut 3 [(dec a) 1] b)\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ux`(zart:un 204)\n0xff\n&gt; `@ux`(zart:un 42)\n0x12\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "zyft"
+    ],
+    "doc": "<h1><code>++zyft</code></h1>\n\n<p>Lookup byte in 256 sub box</p>\n\n<p>The inverse of <code>++zyrt</code>. Looks up a byte <code>a</code> in a substituion box\nwith 256 values, producing a byte.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom of one byte in length.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  zyft                                              ::  forward 256-sbox\n    |=  a/@D\n    =+  ^=  b\n        0xbb49.b71f.b881.b402.17e4.6b86.69b5.1647.115f.dddb.7ca5.\n          8371.4bd5.19a9.b092.605d.0d9b.e030.a0cc.78ba.5706.4d2d.\n          986a.768c.f8e8.c4c7.2f1c.effe.3cae.01c0.253e.65d3.3872.\n          ce0e.7a74.8ac6.daac.7e5c.6479.44ec.4143.3d20.4af0.ee6c.\n          c828.deca.0377.249f.ffcd.7b4f.eb7d.66f2.8951.042e.595a.\n          8e13.f9c3.a79a.f788.6199.9391.7fab.6200.4ce5.0758.e2f1.\n          7594.c945.d218.4248.afa1.e61a.54fb.1482.bea4.96a2.3473.\n          63c2.e7cb.155b.120a.4ed7.bfd8.b31b.4008.f329.fca3.5380.\n          9556.0cb2.8722.2bea.e96e.3ac5.d1bc.10e3.2c52.a62a.b1d6.\n          35aa.d05e.f6a8.0f3b.31ed.559d.09ad.f585.6d21.fd1d.8d67.\n          370b.26f4.70c1.b923.4684.6fbd.cf8b.5036.0539.9cdc.d93f.\n          9068.1edf.8f33.b632.d427.97fa.9ee1\n    (cut 3 [a 1] b)\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (zyft:un 0x12)\n57\n&gt; (zyft:un 0x0)\n225\n&gt; (zyft:un 0xff)\n187\n</code></pre>\n\n<hr/>"
+  },
+
+  {
+    "keys": [
+      "coin"
+    ],
+    "doc": "<h1><code>++coin</code></h1>\n\n<p>Noun literal syntax cases</p>\n\n<p>Noun literal syntax cases: atoms, jammed nouns, and nestable tuples.\nParsed and printed using <code>++so</code> and <code>++co</code> cores.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  coin  $%  {$$ p/dime}                               ::\n              {$blob p/*}                               ::\n              {$many p/(list coin)}                     ::\n          ==                                            ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `coin`(need (slay '~s1'))\n[%$ p=[p=~.dr q=18.446.744.073.709.551.616]]\n&gt; `coin`(need (slay '0x2b59'))\n[%$ p=[p=~.ux q=11.097]]\n\n&gt; ~(rend co [%many ~[[%$ %ud 1] [%$ %tas 'a'] [%$ %s -2]]])\n\"._1_a_-2__\"\n&gt; ._1_a_-2__\n[1 %a -2]\n\n&gt; `@uv`(jam [3 4])\n0v2cd1\n&gt; (slay '~02cd1')\n[~ [%blob p=[3 4]]]\n&gt; ~02cd1\n[3 4]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dime"
+    ],
+    "doc": "<h1><code>++dime</code></h1>\n\n<p>Odor-atom pair</p>\n\n<p>Used in <code>++coin</code>. Convenience methods <code>++scot</code> and <code>++scow</code> (in\nSection 2eL) print dimes as <code>++cord</code> and <code>++tape</code>, respectively.\n<code>++slat</code>, <code>++slav</code>, and <code>++slaw</code> are used to parse atoms of\nspecific odors.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  dime  {p/@ta q/@}                                  ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; +&gt;:(slay '0x123')\np=[p=~.ux q=291]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "edge"
+    ],
+    "doc": "<h1><code>++edge</code></h1>\n\n<p>Parsing location metadata</p>\n\n<p>Optional result <code>p</code> and parsing continuation <code>q</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>        ++  hair  {p/@ud q/@ud}                                 ::  parsing trace\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<p>See also: Section 2eD, <code>++rule</code></p>\n\n<pre><code>&gt; *edge\n[p=[p=0 q=0] q=~]\n&gt; (tall:vast [1 1] \"a b\")\n[p=[p=1 q=2] q=[~ [p=[%cnzz p=~[%a]] q=[p=[p=1 q=2] q=\" b\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "hair"
+    ],
+    "doc": "<h1><code>++hair</code></h1>\n\n<p>Parsing line and column</p>\n\n<p>A pair of two <a href=\"\"><code>@ud</code></a> used in parsing indicating line and column number.</p>\n\n<h2>Source</h2>\n\n<pre><code>        ++  hair  {p/@ud q/@ud}                                 ::  parsing trace\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *hair\n[p=0 q=0]\n\n&gt; `hair`[1 1] :: parsing starts at [1 1] as a convention.\n[p=1 q=1]\n&gt; ((plus ace) [1 1] \"   --\")\n[p=[p=1 q=4] q=[~ u=[p=[~~. \"  \"] q=[p=[p=1 q=4] q=\"--\"]]]]\n&gt; `hair`p:((plus ace) [1 1] \"   --\")\n[p=1 q=4]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "like"
+    ],
+    "doc": "<h1><code>++like</code></h1>\n\n<p>Mold generator for an edge</p>\n\n<p><code>++like</code> generates an <code>++edge</code> with a parsed result set to a specific type.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  like  |*  a/$-(* *)                                 ::  generic edge\n          |=  b/_`*`[(hair) ~]                          ::\n          :-  p=(hair -.b)                              ::\n          ^=  q                                         ::\n          ?@  +.b  ~                                    ::\n          :-  ~                                         ::\n          u=[p=(a +&gt;-.b) q=[p=(hair -.b) q=(tape +.b)]] ::\n</code></pre>\n\n\n<h2>Examples</h2>\n<pre><code>&gt; *(like char)\n[p=[p=0 q=0] q=~]\n\n&gt; (ace [1 1] \" a\")\n[p=[p=1 q=2] q=[~ [p=~~. q=[p=[p=1 q=2] q=\"a\"]]]]\n&gt; `(like char)`(ace [1 1] \" a\")\n[p=[p=1 q=2] q=[~ [p=~~. q=[p=[p=1 q=2] q=\"a\"]]]]\n&gt; `(like ,@)`(ace [1 1] \" a\")\n[p=[p=1 q=2] q=[~ [p=32 q=[p=[p=1 q=2] q=\"a\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "nail"
+    ],
+    "doc": "<h1><code>++nail</code></h1>\n\n<p>Location, remainder of parsed text</p>\n\n<p>Indicates parsing position <code>p</code>, and remaining text to be parsed <code>q</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>        ++  nail  {p/hair q/tape}                               ::  parsing input\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; +&lt;:;~(plug cab cab)\nc=tub=[p=[p=0 q=0] q=\"\"]\n&gt; :: tub is a ++nail\n</code></pre>"
+  },
+  {
+    "keys": [
+      "path"
+    ],
+    "doc": "<h1><code>++path</code></h1>\n\n<p>Filesystem path</p>\n\n<p>A <code>++path</code> is a list of <code>++span</code>s aka <code>@ta</code>. Used in\n<code>%clay</code> and <code>%eyre</code> extensively.</p>\n\n<h2>Source</h2>\n\n<pre><code>        ++  path  (list knot)                                   ::  filesys location\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `path`\"abc\"\n/a/b/c\n</code></pre>"
+  },
+  {
+    "keys": [
+      "pint"
+    ],
+    "doc": "<h1><code>++pint</code></h1>\n\n<p>Parsing range</p>\n\n<p>Mostly used for stacktraces. A <code>++pint</code> is a pair of\n<code>++hair</code>, indicating from <code>p</code> to <code>q</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>        ++  pint  {p/{p/@ q/@} q/{p/@ q/@}}                     ::  line+column range\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; !:(!!)\n! /~zod/try/~2014.9.20..01.22.04..52e3/:&lt;[1 4].[1 6]&gt;\n&gt; :: !! always produces a crash\n&gt; `pint`[[1 4] [1 6]]\n[p=[p=1 q=4] q=[p=1 q=6]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "rule"
+    ],
+    "doc": "<h1><code>++rule</code></h1>\n\n<p>Parsing rule</p>\n\n<p><code>++rule</code> is an empty parsing rule, but it is used to check\nthat parsing rules match this with <code>_</code>.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>        ++  rule  _|=(nail *edge)                               ::  parsing rule\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *rule\n[p=[p=0 q=0] q=[~ [p=0 q=[p=[p=0 q=0] q=\"\"]]]]\n\n&gt; ^+(rule [|=(a=nail [p.a ~])]:|6)\n&lt;1.dww [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;101.jzo 1.ypj %164&gt;]&gt;\n&gt; (^+(rule [|=(a=nail [p.a ~ u=['a' a]])]:|6) [1 1] \"hi\")\n[p=[p=1 q=1] q=[~ [p=97 q=[p=[p=1 q=1] q=\"hi\"]]]]\n&gt; ([|=(a=nail [p.a ~ u=['a' a]])]:|6 [1 1] \"hi\")\n[[p=1 q=1] ~ u=['a' p=[p=1 q=1] q=\"hi\"]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "spot"
+    ],
+    "doc": "<h1><code>++spot</code></h1>\n\n<p>Stack trace line</p>\n\n<p>A <code>++spot</code> is what we print after crashing.</p>\n\n<h2>Source</h2>\n\n<pre><code>        ++  spot  {p/path q/pint}                               ::  range in file\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; :into /=main=/bin/fail/hoon '!:  !!'\n+ /~zod/main/359/bin/fail/hoon\n&gt; :fail\n! /~zod/main/~2014.9.22..18.40.56..ef04/bin/fail/:&lt;[1 5].[1 7]&gt;\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "toon"
+    ],
+    "doc": "<h1><code>++toon</code></h1>\n\n<p>Nock computation result</p>\n\n<p>Either success (<code>%0</code>), a block with list of requests blocked on (<code>%1</code>), or\nfailure with stack trace (<code>%2</code>).</p>\n\n<h2>Source</h2>\n\n<pre><code>        ++  toon  $%  {$0 p/*}                                  ::  success\n                      {$1 p/(list)}                             ::  blocks\n                      {$2 p/(list tank)}                        ::  stack trace\n                                              ==                                            ::\n</code></pre>\n\n\n<h2>Examples</h2>\n<pre><code>&gt; (mock [[20 21] 0 3] $~)\n[%0 p=21]\n&gt; (mock [[0] !=(.^(cy//=main/1))] ,~)\n[%1 p=~[[31.075 1.685.027.454 1.852.399.981 49 0]]]\n&gt; (path [31.075 1.685.027.454 1.852.399.981 49 0])\n/cy/~zod/main/1\n\n&gt; (mock [[1 2] !=(!:(+(.)))] ,~)\n[%2 p=~[[%leaf p=\"/~zod/try/~2014.9.23..18.34.32..d3c5/:&lt;[1 20].[1 24]&gt;\"]]]\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "po"
+    ],
+    "doc": "<h1><code>++po</code></h1>\n\n<pre><code>++  po\n  ~/  %po\n  =+  :-  ^=  sis                                       ::  prefix syllables\n      'dozmarbinwansamlitsighidfidlissogdirwacsabwissib\\\n      /rigsoldopmodfoglidhopdardorlorhodfolrintogsilmir\\\n      /holpaslacrovlivdalsatlibtabhanticpidtorbolfosdot\\\n      /losdilforpilramtirwintadbicdifrocwidbisdasmidlop\\\n      /rilnardapmolsanlocnovsitnidtipsicropwitnatpanmin\\\n      /ritpodmottamtolsavposnapnopsomfinfonbanporworsip\\\n      /ronnorbotwicsocwatdolmagpicdavbidbaltimtasmallig\\\n      /sivtagpadsaldivdactansidfabtarmonranniswolmispal\\\n      /lasdismaprabtobrollatlonnodnavfignomnibpagsopral\\\n      /bilhaddocridmocpacravripfaltodtiltinhapmicfanpat\\\n      /taclabmogsimsonpinlomrictapfirhasbosbatpochactid\\\n      /havsaplindibhosdabbitbarracparloddosbortochilmac\\\n      /tomdigfilfasmithobharmighinradmashalraglagfadtop\\\n      /mophabnilnosmilfopfamdatnoldinhatnacrisfotribhoc\\\n      /nimlarfitwalrapsarnalmoslandondanladdovrivbacpol\\\n      /laptalpitnambonrostonfodponsovnocsorlavmatmipfap'\n      ^=  dex                                           ::  suffix syllables\n      'zodnecbudwessevpersutletfulpensytdurwepserwylsun\\\n      /rypsyxdyrnuphebpeglupdepdysputlughecryttyvsydnex\\\n      /lunmeplutseppesdelsulpedtemledtulmetwenbynhexfeb\\\n      /pyldulhetmevruttylwydtepbesdexsefwycburderneppur\\\n      /rysrebdennutsubpetrulsynregtydsupsemwynrecmegnet\\\n      /secmulnymtevwebsummutnyxrextebfushepbenmuswyxsym\\\n      /selrucdecwexsyrwetdylmynmesdetbetbeltuxtugmyrpel\\\n      /syptermebsetdutdegtexsurfeltudnuxruxrenwytnubmed\\\n      /lytdusnebrumtynseglyxpunresredfunrevrefmectedrus\\\n      /bexlebduxrynnumpyxrygryxfeptyrtustyclegnemfermer\\\n      /tenlusnussyltecmexpubrymtucfyllepdebbermughuttun\\\n      /bylsudpemdevlurdefbusbeprunmelpexdytbyttyplevmyl\\\n      /wedducfurfexnulluclennerlexrupnedlecrydlydfenwel\\\n      /nydhusrelrudneshesfetdesretdunlernyrsebhulryllud\\\n      /remlysfynwerrycsugnysnyllyndyndemluxfedsedbecmun\\\n      /lyrtesmudnytbyrsenwegfyrmurtelreptegpecnelnevfes'\n  |%\n</code></pre>\n\n<p>Provides the phonetic syllables and name generators for the Urbit naming\nsystem. The two faces, <code>sis</code> and <code>dex</code> are available to the arms\ncontained in this section.</p>\n\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "ind"
+    ],
+    "doc": "<h1><code>++ind</code></h1>\n\n<p>Parse prefix</p>\n\n<p>Produces the byte of the right-hand syllable <code>a</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++unit</code> of an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  ind  ~/  %ind                                     ::  parse suffix\n           |=  a/@tas\n           =+  b=0\n           |-  ^-  (unit @)\n           ?:(=(256 b) ~ ?:(=(a (tod b)) [~ b] $(b +(b))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (ind:po 'zod')\n[~ 0]\n&gt; (ind:po 'zam')\n~\n&gt; (ind:po 'del')\n[~ 37]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "ins"
+    ],
+    "doc": "<h1><code>++ins</code></h1>\n\n<p>Parse suffix</p>\n\n<p>Produces the byte of the left-hand phonetic syllable <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<h2>Produces</h2>\n<p>A <code>++unit</code> of an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  ins  ~/  %ins                                     ::  parse prefix\n           |=  a/@tas\n           =+  b=0\n           |-  ^-  (unit @)\n           ?:(=(256 b) ~ ?:(=(a (tos b)) [~ b] $(b +(b))))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (ins:po 'mar')\n[~ 1]\n&gt; (ins:po 'son')\n[~ 164]\n&gt; (ins:po 'pit')\n[~ 242]\n&gt; (ins:po 'pok')\n~\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "tod"
+    ],
+    "doc": "<h1><code>++tod</code></h1>\n\n<p>Fetch prefix</p>\n\n<p>Produces the phonetic prefix syllable from index <code>a</code> within <code>dex</code> as an\natom.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>  ++  tod  ~/  %tod                                     ::  fetch suffix\n           |=(a/@ ?&gt;((lth a 256) (cut 3 [(mul 3 a) 3] dex)))\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@t`(tod:po 1)\n'nec'\n&gt; `@t`(tod:po 98)\n'dec'\n&gt; `@t`(tod:po 0)\n'zod'\n&gt; `@t`(tod:po 150)\n'ryg'\n&gt; `@t`(tod:po 255)\n'fes'\n&gt; `@t`(tod:po 256)\n! exit\n</code></pre>\n\n<hr/>"
+  },
+
+  {
+    "keys": [
+      "at"
+    ],
+    "doc": "<h1><code>++at</code></h1>\n\n<pre><code>++  at\n  |_  a/@\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "r"
+    ],
+    "doc": "<h1><code>++r</code></h1>\n\n<pre><code>  ++  r\n    ?:  ?&amp;  (gte (met 3 a) 2)\n            |-\n            ?:  =(0 a)\n              &amp;\n            =+  vis=(end 3 1 a)\n            ?&amp;  ?|(=('-' vis) ?&amp;((gte vis 'a') (lte vis 'z')))\n                $(a (rsh 3 1 a))\n            ==\n        ==\n      rtam\n    ?:  (lte (met 3 a) 2)\n      rud\n    rux\n  ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rf"
+    ],
+    "doc": "<h1><code>++rf</code></h1>\n\n<pre><code>  ++  rf    `tape`[?-(a $&amp; '&amp;', $| '|', * !!) ~]\n</code></pre>\n\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rn"
+    ],
+    "doc": "<h1><code>++rn</code></h1>\n\n<pre><code>    ++  rn    `tape`[?&gt;(=(0 a) '~') ~]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rt"
+    ],
+    "doc": "<h1><code>++rt</code></h1>\n\n<pre><code>    ++  rt    `tape`['\\'' (weld (mesc (trip a)) `tape`['\\'' ~])]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rta"
+    ],
+    "doc": "<h1><code>++rta</code></h1>\n\n<pre><code>    ++  rta   rt\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rtam"
+    ],
+    "doc": "<h1><code>++rtam</code></h1>\n\n<pre><code>  ++  rtam  `tape`['%' (trip a)]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rub"
+    ],
+    "doc": "<h1><code>++rub</code></h1>\n\n<pre><code>  ++  rub   `tape`['0' 'b' (rum 2 ~ |=(b/@ (add '0' b)))]\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rud"
+    ],
+    "doc": "<h1><code>++rud</code></h1>\n\n<pre><code>  ++  rud   (rum 10 ~ |=(b/@ (add '0' b)))\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rum"
+    ],
+    "doc": "<h1><code>++rum</code></h1>\n\n<pre><code>  ++  rum\n    |=  {b/@ c/tape d/$-(@ @)}\n    ^-  tape\n    ?:  =(0 a)\n      [(d 0) c]\n    =+  e=0\n    |-  ^-  tape\n    ?:  =(0 a)\n      c\n    =+  f=&amp;(!=(0 e) =(0 (mod e ?:(=(10 b) 3 4))))\n    %=  $\n      a  (div a b)\n      c  [(d (mod a b)) ?:(f [?:(=(10 b) ',' '-') c] c)]\n      e  +(e)\n    ==\n  ::\n</code></pre>\n\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rup"
+    ],
+    "doc": "<h1><code>++rup</code></h1>\n\n<pre><code>  ++  rup\n    =+  b=(met 3 a)\n    ^-  tape\n    :-  '-'\n    |-  ^-  tape\n    ?:  (gth (met 5 a) 1)\n      %+  weld\n        $(a (rsh 5 1 a), b (sub b 4))\n      `tape`['-' '-' $(a (end 5 1 a), b 4)]\n    ?:  =(0 b)\n      ['~' ~]\n    ?:  (lte b 1)\n      (trip (tos:po a))\n    |-  ^-  tape\n    ?:  =(2 b)\n      =+  c=(rsh 3 1 a)\n      =+  d=(end 3 1 a)\n      (weld (trip (tod:po c)) (trip (tos:po (mix c d))))\n    =+  c=(rsh 3 2 a)\n    =+  d=(end 3 2 a)\n    (weld ^$(a c, b (met 3 c)) `tape`['-' $(a (mix c d), b 2)])\n  ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "ruv"
+    ],
+    "doc": "<h1><code>++ruv</code></h1>\n\n<pre><code>  ++  ruv\n    ^-  tape\n    :+  '0'\n      'v'\n    %^    rum\n        64\n      ~\n    |=  b/@\n    ?:  =(63 b)\n      '+'\n    ?:  =(62 b)\n      '-'\n    ?:((lth b 26) (add 65 b) ?:((lth b 52) (add 71 b) (sub b 4)))\n  ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "rux"
+    ],
+    "doc": "<h1><code>++rux</code></h1>\n\n<pre><code>  ++  rux  `tape`['0' 'x' (rum 16 ~ |=(b/@ (add b ?:((lth b 10) 48 87))))]\n  --\n  ::::::::::::::::::::::::::::::::::::::::::::::::::::::  ::\n</code></pre>\n\n<p>XX document</p>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "cass"
+    ],
+    "doc": "<h1><code>++cass</code></h1>\n\n<p>To lowercase</p>\n\n<p>Produce the case insensitive (all lowercase) <a href=\"\"><code>++cord</code></a> of a <a href=\"\"><code>++tape</code></a>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>vib</code> is a <code>++tape</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++cord</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cass                                                ::  lowercase\n  |=  vib/tape\n  %+  rap  3\n  (turn vib |=(a/@ ?.(&amp;((gte a 'A') (lte a 'Z')) a (add 32 a))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (cass \"john doe\")\n7.309.170.810.699.673.450\n&gt; `cord`(cass \"john doe\")\n'john doe'\n&gt; (cass \"abc, 123, !@#\")\n2.792.832.775.110.938.439.066.079.945.313\n&gt; `cord`(cass \"abc, 123, !@#\")\n'abc, 123, !@#'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "crip"
+    ],
+    "doc": "<h1><code>++crip</code></h1>\n\n<p>Tape to cord</p>\n\n<p>Produce a <code>++cord</code> from a <code>++tape</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++tape</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++cord</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  crip  |=(a=tape `@t`(rap 3 a))                      ::  tape to cord\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (crip \"john doe\")\n'john doe'\n&gt; (crip \"abc 123 !@#\")\n'abc 123 !@#'\n&gt; `@ud`(crip \"abc\")\n6.513.249\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cuss"
+    ],
+    "doc": "<h1><code>++cuss</code></h1>\n\n<p>To uppercase</p>\n\n<p>Turn all occurances of lowercase letters in any <code>++tape</code> into uppercase\nletters, as a <code>++cord</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>vib</code> is a <code>++tape</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++cord</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cuss                                                ::  uppercase\n  |=  vib=tape\n  ^-  @t\n  %+  rap  3\n  (turn vib |=(a=@ ?.(&amp;((gte a 'a') (lte a 'z')) a (sub a 32))))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (cuss \"john doe\")\n'JOHN DOE'\n&gt; (cuss \"abc ABC 123 !@#\")\n'ABC ABC 123 !@#'\n&gt; `@ud`(cuss \"abc\")\n4.407.873\n&gt; (cuss \"AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsQqRrVvWwXxYyZz\")\n'AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSQQRRVVWWXXYYZZ'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mesc"
+    ],
+    "doc": "<h1><code>++mesc</code></h1>\n\n<p>Escape special chars</p>\n\n<p>Escape special characters, used in <code>++show</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>vib</code> is a <code>++tape</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++tape</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mesc                                                ::  ctrl code escape\n  |=  vib/tape\n  ^-  tape\n  ?~  vib\n    ~\n  ?:  =('\\\\' i.vib)\n    ['\\\\' '\\\\' $(vib t.vib)]\n  ?:  ?|((gth i.vib 126) (lth i.vib 32) =(`@`39 i.vib))\n    ['\\\\' (welp ~(rux at i.vib) '/' $(vib t.vib))]\n  [i.vib $(vib t.vib)]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (mesc \"ham lus\")\n\"ham lus\"\n/&gt; (mesc \"bas\\\\hur\")\n\"bas\\\\\\\\hur\"\n/&gt; (mesc \"as'saß\")\n\"as\\0x27/sa\\0xc3/\\0x9f/\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "runt"
+    ],
+    "doc": "<h1><code>++runt</code></h1>\n\n<p>Prepend <code>n</code> times</p>\n\n<p>Add <code>a</code> repetitions of character <code>b</code> to the head of <code>++tape</code> <code>c</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> and <code>b</code> are atoms.</p>\n\n<p><code>c</code> is a <code>++tape</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++tape</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  runt                                                ::  prepend repeatedly\n  |=  [[a/@ b/@] c/tape]\n  ^-  tape\n  ?:  =(0 a)\n    c\n  [b $(a (dec a))]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (runt [2 '/'] \"ham\")\n\"//ham\"\n/&gt; (runt [10 'a'] \"\")\n\"aaaaaaaaaa\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sand"
+    ],
+    "doc": "<h1><code>++sand</code></h1>\n\n<p>Soft-cast by odor</p>\n\n<p>Soft-cast validity by odor.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++span</code> (<code>@ta</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>(unit @)</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  sand                                                ::  atom sanity\n  |=  a/@ta\n  |=  b/@  ^-  (unit @)\n  ?.(((sane a) b) ~ [~ b])\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; `(unit @ta)`((sand %ta) 'sym-som')\n[~ ~.sym-som]\n/&gt; `(unit @ta)`((sand %ta) 'err!')\n~\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sane"
+    ],
+    "doc": "<h1><code>++sane</code></h1>\n\n<p>Check odor validity</p>\n\n<p>Check validity by odor. Produces a gate.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++span</code> (<code>@ta</code>).</p>\n\n<p><code>b</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A boolean.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  sane                                                ::  atom sanity\n  |=  a/@ta\n  |=  b/@  ^-  ?\n  ?.  =(%t (end 3 1 a))\n    ~|(%sane-stub !!)\n  =+  [inx=0 len=(met 3 b)]\n  ?:  =(%tas a)\n    |-  ^-  ?\n    ?:  =(inx len)  &amp;\n    =+  cur=(cut 3 [inx 1] b)\n    ?&amp;  ?|  &amp;((gte cur 'a') (lte cur 'z'))\n            &amp;(=('-' cur) !=(0 inx) !=(len inx))\n            &amp;(&amp;((gte cur '0') (lte cur '9')) !=(0 inx))\n        ==\n        $(inx +(inx))\n    ==\n  ?:  =(%ta a)\n    |-  ^-  ?\n    ?:  =(inx len)  &amp;\n    =+  cur=(cut 3 [inx 1] b)\n    ?&amp;  ?|  &amp;((gte cur 'a') (lte cur 'z'))\n            &amp;((gte cur '0') (lte cur '9'))\n            |(=('-' cur) =('~' cur) =('_' cur) =('.' cur))\n        ==\n        $(inx +(inx))\n    ==\n  |-  ^-  ?\n  ?:  =(0 b)  &amp;\n  =+  cur=(end 3 1 b)\n  ?:  &amp;((lth cur 32) !=(10 cur))  |\n  =+  len=(teff cur)\n  ?&amp;  |(=(1 len) =+(i=1 |-(|(=(i len) &amp;((gte (cut 3 [i 1] b) 128) $(i +(i)))))))\n      $(b (rsh 3 len b))\n  ==\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; ((sane %tas) %mol)\n%.y\n/&gt; ((sane %tas) 'lam')\n%.y\n/&gt; ((sane %tas) 'more ace')\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "teff"
+    ],
+    "doc": "<h1><code>++teff</code></h1>\n\n<p>UTF8 Length</p>\n\n<p>Produces the number of utf8 bytes.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>@t</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  |=  a/@t  ^-  @\n  =+  b=(end 3 1 a)\n  ~|  %bad-utf8\n  ?:  =(0 b)\n    ?&gt;(=(`@`0 a) 0)\n  ?&gt;  |((gte b 32) =(10 b))\n  ?:((lte b 127) 1 ?:((lte b 223) 2 ?:((lte b 239) 3 4)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (teff 'a')\n1\n/&gt; (teff 'ß')\n2\n</code></pre>"
+  },
+  {
+    "keys": [
+      "trim"
+    ],
+    "doc": "<h1><code>++trim</code></h1>\n\n<p>Tape split</p>\n\n<p>Split first <code>a</code> characters off <code>++tape</code> <code>b</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<p><code>b</code> is a <code>++tape</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A cell of <code>++tape</code>s, <code>p</code> and <code>q</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  trim                                              ::  31-bit nonzero\n    |=  key/@\n    =+  syd=0xcafe.babe\n    |-  ^-  @\n    =+  haz=(spec syd key)\n    =+  ham=(mix (rsh 0 31 haz) (end 0 31 haz))\n    ?.(=(0 ham) ham $(syd +(syd)))\n  --\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (trim 5 \"lasok termun\")\n[p=\"lasok\" q=\" termun\"]\n/&gt; (trim 5 \"zam\")\n[p=\"zam\" q=\"\"]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "trip"
+    ],
+    "doc": "<h1><code>++trip</code></h1>\n\n<p>Cord to tape</p>\n\n<p>Produce a <code>++tape</code> from <code>++cord</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++tape</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  trip                                                ::  cord to tape\n  ~/  %trip\n  |=  a/@  ^-  tape\n  ?:  =(0 (met 3 a))\n    ~\n  [^-(@ta (end 3 1 a)) $(a (rsh 3 1 a))]\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (trip 'john doe')\n\"john doe\"\n/&gt; (trip 'abc 123 !@#')\n\"abc 123 !@#\"\n/&gt; (trip 'abc')\n\"abc\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tuba"
+    ],
+    "doc": "<h1><code>++tuba</code></h1>\n\n<p>UTF8 to UTF32 tape</p>\n\n<p>Convert <code>++tape</code> to a <code>++list</code> of codepoints (<code>@c</code>).</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++tape</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++list</code> of codepoints <code>@c</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  tuba                                                ::  utf8 to utf32 tape\n  |=  a/tape\n  ^-  (list @c)\n  (rip 5 (turf (rap 3 a)))                              ::  XX horrible\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (tuba \"я тут\")\n~[~-~44f. ~-. ~-~442. ~-~443. ~-~442.]\n/&gt; (tuba \"chars\")\n~[~-c ~-h ~-a ~-r ~-s]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tufa"
+    ],
+    "doc": "<h1><code>++tufa</code></h1>\n\n<p>UTF32 to UTF8 tape</p>\n\n<p>Wrap a <code>++list</code> of utf32 codepoints into a utf8 <code>++tape</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++list</code> of <code>@c</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++tape</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  tufa                                                ::  utf32 to utf8 tape\n  |=  a=(list @c)\n  ^-  tape\n  ?~  a  \"\"\n  (weld (rip 3 (tuft i.a)) $(a t.a))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (tufa ~[~-~44f. ~-. ~-~442. ~-~443. ~-~442.])\n\"я тут\"\n/&gt; (tufa ((list @c) ~[%a %b 0xb1 %c]))\n\"ab±c\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tuft"
+    ],
+    "doc": "<h1><code>++tuft</code></h1>\n\n<p>UTF32 to UTF8 text</p>\n\n<p>Convert utf32 glyph to\nLSB utf8 <code>++cord</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a codepoint (<code>@c</code>).</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++cord</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  tuft                                                ::  utf32 to utf8 text\n  |=  a/@c\n  ^-  @t\n  %+  rap  3\n  |-  ^-  (list @)\n  ?:  =(`@`0 a)\n    ~\n  =+  b=(end 5 1 a)\n  =+  c=$(a (rsh 5 1 a))\n  ?:  (lte b 0x7f)\n    [b c]\n  ?:  (lte b 0x7ff)\n    :*  (mix 0b1100.0000 (cut 0 [6 5] b))\n        (mix 0b1000.0000 (end 0 6 b))\n        c\n    ==\n  ?:  (lte b 0xffff)\n    :*  (mix 0b1110.0000 (cut 0 [12 4] b))\n        (mix 0b1000.0000 (cut 0 [6 6] b))\n        (mix 0b1000.0000 (end 0 6 b))\n        c\n    ==\n  :*  (mix 0b1111.0000 (cut 0 [18 3] b))\n      (mix 0b1000.0000 (cut 0 [12 6] b))\n      (mix 0b1000.0000 (cut 0 [6 6] b))\n      (mix 0b1000.0000 (end 0 6 b))\n      c\n  ==\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (tuft `@c`%a)\n'a'\n/&gt; (tuft `@c`0xb6)\n'¶'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "turf"
+    ],
+    "doc": "<h1><code>++turf</code></h1>\n\n<p>UTF8 to UTF32 cord</p>\n\n<p>Convert utf8 (<code>++cord</code>) to utf32 codepoints.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>@t</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>@c</code>, UTF-32 codepoint.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  turf                                                ::  utf8 to utf32\n  |=  a/@t\n  ^-  @c\n  %+  rap  5\n  |-  ^-  (list @c)\n  =+  b=(teff a)\n  ?:  =(0 b)  ~\n  =+  ^=  c\n      %+  can  0\n      %+  turn\n        ^-  (list {p/@ q/@})\n        ?+  b  !!\n          $1  [[0 7] ~]\n          $2  [[8 6] [0 5] ~]\n          $3  [[16 6] [8 6] [0 4] ~]\n          $4  [[24 6] [16 6] [8 6] [0 3] ~]\n        ==\n      |=({p/@ q/@} [q (cut 0 [p q] a)])\n  ?.  =((tuft c) (end 3 b a))  ~|(%bad-utf8 !!)\n  [c $(a (rsh 3 b a))]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (turf 'my ßam')\n~-my.~df.am\n/&gt; 'я тут'\n'я тут'\n/&gt; (turf 'я тут')\n~-~44f..~442.~443.~442.\n/&gt; `@ux`'я тут'\n0x82.d183.d182.d120.8fd1\n/&gt; `@ux`(turf 'я тут')\n0x442.0000.0443.0000.0442.0000.0020.0000.044f\n</code></pre>"
+  },
+  {
+    "keys": [
+      "wack"
+    ],
+    "doc": "<h1><code>++wack</code></h1>\n\n<p>Coin format encode</p>\n\n<p>Escape <code>++span</code> <code>~</code> as <code>~~</code> and <code>_</code> as <code>~-</code>. Used for printing.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>++span</code> (<code>@ta</code>).</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++span</code> (<code>@ta</code>).</p>\n\n<h2>Source</h2>\n\n<pre><code>++  wack                                                ::  coin format\n  |=  a/@ta\n  ^-  @ta\n  =+  b=(rip 3 a)\n  %+  rap  3\n  |-  ^-  tape\n  ?~  b\n    ~\n  ?:  =('~' i.b)  ['~' '~' $(b t.b)]\n  ?:  =('_' i.b)  ['~' '-' $(b t.b)]\n  [i.b $(b t.b)]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (wack '~20_sam~')\n~.~~20~-sam~~\n/&gt; `@t`(wack '~20_sam~')\n'~~20~-sam~~'\n&gt; ~(rend co %many ~[`ud/5 `ta/'~20_sam'])\n\"._5_~~.~~20~-sam__\"\n&gt; ._5_~~.~~20~-sam__\n[5 ~.~20_sam]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "wick"
+    ],
+    "doc": "<h1><code>++wick</code></h1>\n\n<p>Coin format decode</p>\n\n<p>Unescape <code>++span</code> <code>~~</code> as <code>~</code> and <code>~-</code> as <code>_</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++span</code> <code>@ta</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  wick                                                ::  knot format\n  |=  a/@\n  ^-  (unit @ta)\n  =+  b=(rip 3 a)\n  =-  ?^(b ~ (some (rap 3 (flop c))))\n  =|  c/tape\n  |-  ^-  {b/tape c/tape}\n  ?~  b  [~ c]\n  ?.  =('~' i.b)\n    $(b t.b, c [i.b c])\n  ?~  t.b  [b ~]\n  ?-  i.t.b\n    $'~'  $(b t.t.b, c ['~' c])\n    $'-'  $(b t.t.b, c ['_' c])\n    @     [b ~]\n  ==\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; `@t`(wick '~-ams~~lop')\n'_ams~lop'\n/&gt; `@t`(wick (wack '~20_sam~'))\n'~20_sam~'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "woad"
+    ],
+    "doc": "<h1><code>++woad</code></h1>\n\n<p>Unescape cord</p>\n\n<p>Unescape <code>++cord</code> codepoints.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is a <code>@ta</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++cord</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  woad                                                ::  cord format\n  |=  a/@ta\n  ^-  @t\n  %+  rap  3\n  |-  ^-  (list @)\n  ?:  =(`@`0 a)\n    ~\n  =+  b=(end 3 1 a)\n  =+  c=(rsh 3 1 a)\n  ?:  =('.' b)\n    [' ' $(a c)]\n  ?.  =('~' b)\n    [b $(a c)]\n  =&gt;  .(b (end 3 1 c), c (rsh 3 1 c))\n  ?+  b  =-  (weld (rip 3 (tuft p.d)) $(a q.d))\n         ^=  d\n         =+  d=0\n         |-  ^-  {p/@ q/@}\n         ?:  =('.' b)\n           [d c]\n         ?&lt;  =(0 c)\n         %=    $\n            b  (end 3 1 c)\n            c  (rsh 3 1 c)\n            d  %+  add  (mul 16 d)\n               %+  sub  b\n               ?:  &amp;((gte b '0') (lte b '9'))  48\n               ?&gt;(&amp;((gte b 'a') (lte b 'z')) 87)\n         ==\n    $'.'  ['.' $(a c)]\n    $'~'  ['~' $(a c)]\n  ==\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (woad ~.~b6.20.as)\n'¶20 as'\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "re"
+    ],
+    "doc": "<h1><code>++re</code></h1>\n\n<p>Pretty-printing engine</p>\n\n<p>Pretty-printing engine that accepts a <code>++tank</code> sample and contains arms that perform computation on it.</p>\n\n<h2>Accepts</h2>\n\n<p><code>tac</code> is a <code>++tank</code>.</p>\n\n<h2>Produces</h2>\n\n<pre><code>++  re\n  |_  tac/tank\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; ~(. re leaf+\"ham\")\n&lt;2.gdc {tac/{$leaf \"\"} &lt;402.arm 110.jyx 1.ztu $151&gt;}&gt;\n</code></pre>"
+  },
+  {
+    "keys": [
+      "ram"
+    ],
+    "doc": "<h1><code>++ram</code></h1>\n\n<p>Flatten to tape</p>\n\n<p>Flatten <code>++tank</code> out into a <code>++tape</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>tac</code> is a <code>++tank</code>, taken from sample of <code>++re</code> core.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++tape</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  ram\n    ^-  tape\n    ?-    -.tac\n        $leaf  p.tac\n        $palm  ram(tac [%rose [p.p.tac (weld q.p.tac r.p.tac) s.p.tac] q.tac])\n        $rose\n      %+  weld\n        q.p.tac\n      |-  ^-  tape\n      ?~  q.tac\n        r.p.tac\n      =+  voz=$(q.tac t.q.tac)\n      (weld ram(tac i.q.tac) ?~(t.q.tac voz (weld p.p.tac voz)))\n    ==\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; ~(ram re leaf+\"foo\")\n\"foo\"\n/&gt; ~(ram re rose+[\".\" \"(\" \")\"]^~[leaf+\"bar\" leaf+\"baz\" leaf+\"bam\"])\n\"(bar.baz.bam)\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "win"
+    ],
+    "doc": "<h1><code>++win</code></h1>\n\n<p>Render at indent</p>\n\n<p>Render at indent level <code>tab</code> and width <code>edg</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>tac</code> is a <code>++tank</code>, taken from sample of <code>++re</code> core.</p>\n\n<p><code>tab</code> and <code>edg</code> are atoms.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++wall</code> (<code>++list</code> of <code>++tapes</code>).</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  win\n    |=  {tab/@ edg/@}\n    =+  lug=`wall`~\n    |^  |-  ^-  wall\n        ?-    -.tac\n            $leaf  (rig p.tac)\n            $palm\n          ?:  fit\n            (rig ram)\n          ?~  q.tac\n            (rig q.p.tac)\n          ?~  t.q.tac\n            (rig(tab (add 2 tab), lug $(tac i.q.tac)) q.p.tac)\n          =&gt;  .(q.tac `(list tank)`q.tac)\n          =+  lyn=(mul 2 (lent q.tac))\n          =+  ^=  qyr\n              |-  ^-  wall\n              ?~  q.tac\n                lug\n              %=  ^$\n                tac  i.q.tac\n                tab  (add tab (sub lyn 2))\n                lug  $(q.tac t.q.tac, lyn (sub lyn 2))\n              ==\n          (wig(lug qyr) q.p.tac)\n        ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; (~(win re leaf+\"samoltekon-lapdok\") 0 20)\n&lt;&lt;\"samoltekon-lapdok\"&gt;&gt;\n/&gt; (~(win re leaf+\"samoltekon-lapdok\") 0 10)\n&lt;&lt;\"\\/samolt\\/\" \"  ekon-l\" \"  apdok\" \"\\/      \\/\"&gt;&gt;\n/&gt; (~(win re rose+[\"--\" \"[\" \"]\"]^~[leaf+\"1423\" leaf+\"2316\"]) 0 20)\n&lt;&lt;\"[1423--2316]\"&gt;&gt;\n/&gt; (~(win re rose+[\"--\" \"[\" \"]\"]^~[leaf+\"1423\" leaf+\"2316\"]) 0 10)\n&lt;&lt;\"[ 1423\" \"  2316\" \"]\"&gt;&gt;\n</code></pre>"
+  },
+  {
+    "keys": [
+      "din"
+    ],
+    "doc": "<h1><code>++din</code></h1>\n\n<p>XX document</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>    ++  din  (mod (add 2 tab) (mul 2 (div edg 3)))\n</code></pre>\n\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "fit"
+    ],
+    "doc": "<h1><code>++fit</code></h1>\n\n<p>Fit on one line test</p>\n\n<p>Determine whether <code>tac</code> fits on one line. Internal to <code>++win</code></p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<p>++  fit  (lte (lent ram) (sub edg tab))</p>\n\n\n<h2>Examples</h2>\n\n\n\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rig"
+    ],
+    "doc": "<h1><code>++rig</code></h1>\n\n<p>Wrap in <code>\\/</code></p>\n\n<p>Wrap <code>++tape</code> in <code>\\/</code> if it doesn't fit at current indentation. Internal to\n<code>++win</code></p>\n\n<h2>Accepts</h2>\n\n<p><code>tac</code> is a <code>++tank</code>, taken from sample of <code>++re</code> core.</p>\n\n<p><code>hom</code> is a <code>++tape</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++wall</code> (list of <code>++tape</code>s).</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  rig\n      |=  hom/tape\n      ^-  wall\n      ?:  &amp; ::(lte (lent hom) (sub edg tab))\n        [(runt [tab ' '] hom) lug]\n      =&gt;  .(tab (add tab 2), edg (sub edg 2))\n      =+  mut=(trim (sub edg tab) hom)\n      :-  (runt [(sub tab 2) ' '] ['\\\\' '/' (weld p.mut `_hom`['\\\\' '/' ~])])\n      =&gt;  .(hom q.mut)\n      |-\n      ?~  hom\n        :-  %+  runt\n              [(sub tab 2) ' ']\n            ['\\\\' '/' (runt [(sub edg tab) ' '] ['\\\\' '/' ~])]\n        lug\n      =&gt;  .(mut (trim (sub edg tab) hom))\n      [(runt [tab ' '] p.mut) $(hom q.mut)]\n    ::\n</code></pre>\n\n<h2>Examples</h2>"
+  },
+  {
+    "keys": [
+      "wig"
+    ],
+    "doc": "<h1><code>++wig</code></h1>\n\n<p><code>++win</code> render tape</p>\n\n<p>Render <code>++tape</code>. Internal to <code>++win</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>tac</code> is a <code>++tank</code>, taken from sample of <code>++re</code> core.</p>\n\n<p><code>hom</code> is a <code>++tape</code>.</p>\n\n<h2>Produces</h2>\n\n<pre><code>    ++  wig\n      |=  hom/tape\n      ^-  wall\n      ?~  lug\n        (rig hom)\n      =+  lin=(lent hom)\n      =+  wug=:(add 1 tab lin)\n      ?.  =+  mir=i.lug\n          |-  ?~  mir\n                |\n              ?|(=(0 wug) ?&amp;(=(' ' i.mir) $(mir t.mir, wug (dec wug))))\n        (rig hom)       :: ^ XX regular form?\n      [(runt [tab ' '] (weld hom `tape`[' ' (slag wug i.lug)])) t.lug]\n    --\n  --\n</code></pre>"
+  },
+  {
+    "keys": [
+      "show"
+    ],
+    "doc": "<h1><code>++show</code></h1>\n\n<pre><code>++  show                            ::  XX deprecated, use span\n  |=  vem/*\n  |^  ^-  tank\n      ?:  ?=(@ vem)\n        [%leaf (mesc (trip vem))]\n      ?-    vem\n          {s/$~ c/*}\n        [%leaf '\\'' (weld (mesc (tape +.vem)) `tape`['\\'' ~])]\n      ::\n          {s/$a c/@}        [%leaf (mesc (trip c.vem))]\n          {s/$b c/*}        (shop c.vem |=(a/@ ~(rub at a)))\n          {s/{$c p/@} c/*}\n        :+  %palm\n          [['.' ~] ['-' ~] ~ ~]\n        [[%leaf (mesc (trip p.s.vem))] $(vem c.vem) ~]\n      ::\n          {s/$d c/*}        (shop c.vem |=(a/@ ~(rud at a)))\n          {s/$k c/*}        (tank c.vem)\n          {s/$h c/*}\n        :+  %rose\n          [['/' ~] ['/' ~] ~]\n        =+  yol=((list @ta) c.vem)\n        (turn yol |=(a/@ta [%leaf (trip a)]))\n      ::\n          {s/$l c/*}        (shol c.vem)\n          {s/$o c/*}\n        %=    $\n            vem\n          :-  [%m '%h:&lt;[%d %d].[%d %d]&gt;']\n          [-.c.vem +&lt;-.c.vem +&lt;+.c.vem +&gt;-.c.vem +&gt;+.c.vem ~]\n        ==\n      ::\n          {s/$p c/*}        (shop c.vem |=(a/@ ~(rup at a)))\n          {s/$q c/*}        (shop c.vem |=(a/@ ~(r at a)))\n          {s/$r c/*}        $(vem [[%r ' ' '{' '}'] c.vem])\n          {s/$t c/*}        (shop c.vem |=(a/@ ~(rt at a)))\n          {s/$v c/*}        (shop c.vem |=(a/@ ~(ruv at a)))\n          {s/$x c/*}        (shop c.vem |=(a/@ ~(rux at a)))\n          {s/{$m p/@} c/*}  (shep p.s.vem c.vem)\n          {s/{$r p/@} c/*}\n        $(vem [[%r ' ' (cut 3 [0 1] p.s.vem) (cut 3 [1 1] p.s.vem)] c.vem])\n      ::\n          {s/{$r p/@ q/@ r/@} c/*}\n        :+  %rose\n          :*  p=(mesc (trip p.s.vem))\n              q=(mesc (trip q.s.vem))\n              r=(mesc (trip r.s.vem))\n          ==\n        |-  ^-  (list tank)\n        ?@  c.vem\n          ~\n        [^$(vem -.c.vem) $(c.vem +.c.vem)]\n      ::\n          {s/$z c/*}        $(vem [[%r %$ %$ %$] c.vem])\n          *                 !!\n      ==\n</code></pre>\n\n<p>XX document</p>"
+  },
+  {
+    "keys": [
+      "shep"
+    ],
+    "doc": "<h1><code>++shep</code></h1>\n\n<pre><code>  ++  shep\n    |=  {fom/@ gar/*}\n    ^-  tank\n    =+  l=(met 3 fom)\n    =+  i=0\n    :-  %leaf\n    |-  ^-  tape\n    ?:  (gte i l)\n      ~\n    =+  c=(cut 3 [i 1] fom)\n    ?.  =(37 c)\n      (weld (mesc [c ~]) $(i +(i)))\n    =+  d=(cut 3 [+(i) 1] fom)\n    ?.  .?(gar)\n      ['\\\\' '#' $(i (add 2 i))]\n    (weld ~(ram re (show d -.gar)) $(i (add 2 i), gar +.gar))\n  ::\n</code></pre>\n\n<p>XX document</p>"
+  },
+
+  {
+    "keys": [
+      "last"
+    ],
+    "doc": "<h1><code>++last</code></h1>\n\n<p>Farther trace</p>\n\n<p>Compares two line-column pairs, called <code>++hair</code>s, <code>zyc</code> and <code>naz</code>, producing whichever\nis further along.</p>\n\n<h2>Accepts</h2>\n\n<p><code>naz</code> is a hair.</p>\n\n<p><code>zyc</code> is a hair.</p>\n\n<h2>Produces</h2>\n\n<p>a <code>++hair</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  last  |=  {zyc/hair naz/hair}                       ::  farther trace\n          ^-  hair\n          ?:  =(p.zyc p.naz)\n            ?:((gth q.zyc q.naz) zyc naz)\n          ?:((gth p.zyc p.naz) zyc naz)\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (last [1 1] [1 2])\n[p=1 q=2]\n&gt; (last [2 1] [1 2])\n[p=2 q=1]\n&gt; (last [0 0] [99 0])\n[p=99 q=0]\n&gt; (last [7 7] [7 7])\n[p=7 q=7]\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "bend"
+    ],
+    "doc": "<h1><code>++bend</code></h1>\n\n<p>Conditional composer</p>\n\n<p>Parsing composer: connects the <code>++edge</code> <code>vex</code> with the subsequent <code>++rule</code> <code>sab</code>\nas an optional suffix, using gate <code>raq</code> to compose or reject its\nresult. If there is no suffix, or if the suffix fails to be composed\nwith the current result, the current result is produced. Used to map a\ngroup of rules to a specified output.</p>\n\n<h2>Accepts</h2>\n\n<p><code>raq</code> is a gate.</p>\n\n<p><code>sab</code> is a rule.</p>\n\n<p><code>vex</code> is an edge.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bend                                                ::  conditional comp\n  ~/  %bend\n  |*  raq/_|*({a/* b/*} [~ u=[a b]])\n  ~/  %fun\n  |*  {vex/edge sab/rule}\n  ?~  q.vex\n    vex\n  =+  yit=(sab q.u.q.vex)\n  =+  yur=(last p.vex p.yit)\n  ?~  q.yit\n    [p=yur q=q.vex]\n  =+  vux=(raq p.u.q.vex p.u.q.yit)\n  ?~  vux\n    [p=yur q=q.vex]\n  [p=yur q=[~ u=[p=u.vux q=q.u.q.yit]]]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (;~((bend |=([a/char b/char] ?.(=(a b) ~ (some +(a))))) prn prn) [1 1] \"qs\")\n[p=[p=1 q=3] q=[~ u=[p=~~q q=[p=[p=1 q=2] q=\"s\"]]]]\n&gt; (;~((bend |=([a/char b/char] ?.(=(a b) ~ (some +(a))))) prn prn) [1 1] \"qqq\")\n[p=[p=1 q=3] q=[~ u=[p=~~r q=[p=[p=1 q=3] q=\"q\"]]]]\n&gt; (scan \"aa\" ;~((bend |=([a/char b/char] ?.(=(a b) ~ (some +(a))))) prn prn))\n~~b\n&gt; (scan \"ba\" ;~((bend |=([a/char b/char] ?.(=(a b) ~ (some +(a))))) prn prn))\n! {1 3}\n! exit\n&gt; `(unit @tas)`(scan \"\" ;~((bend) (easy ~) sym))\n~\n&gt; `(unit @tas)`(scan \"sep\" ;~((bend) (easy ~) sym))\n[~ %sep]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "comp"
+    ],
+    "doc": "<h1><code>++comp</code></h1>\n\n<p>Arbitrary compose</p>\n\n<p>Parsing composer: connects the <code>++edge</code> <code>vex</code> with a following <code>++rule</code> <code>sab</code>,\ncombining the contents of <code>vex</code> with the result of <code>sab</code> using a binary\ngate <code>raq</code>. Used to fold over the results of several <code>++rules</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>raq</code> is a gate that accepts a cell of two nouns, <code>a</code> and <code>b</code>, and\nproduces a cell of two nouns.</p>\n\n<p><code>sab</code> is a rule.</p>\n\n<p><code>vex</code> is an edge.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  comp\n  ~/  %comp\n  |*  raq/_|*({a/* b/*} [a b])                       ::  arbitrary compose\n  ~/  %fun\n  |*  {vex/edge sab/rule}\n  ~!  +&lt;\n  ?~  q.vex\n    vex\n  =+  yit=(sab q.u.q.vex)\n  =+  yur=(last p.vex p.yit)\n  ?~  q.yit\n    [p=yur q=q.yit]\n  [p=yur q=[~ u=[p=(raq p.u.q.vex p.u.q.yit) q=q.u.q.yit]]]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"123\" ;~((comp |=([a/@u b/@u] (add a b))) dit dit dit))\n6\n&gt; (scan \"12\" ;~((comp |=([a/@u b/@u] (add a b))) dit dit dit))\n! {1 3}\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "fail"
+    ],
+    "doc": "<h1><code>++fail</code></h1>\n\n<p>Never parse</p>\n\n<p>Produces an <code>++edge</code> at the same text position (<code>++hair</code>) with a failing\nresult (<code>q=~</code>).</p>\n\n<h2>Accepts</h2>\n\n<p><code>tub</code> is a <code>++nail</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An <code>++edge</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  fail  |=(tub/nail [p=p.tub q=~])                    ::  never parse\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (fail [[1 1] \"abc\"])\n[p=[p=1 q=1] q=~]\n&gt; (fail [[p=1.337 q=70] \"Parse me, please?\"])\n[p=[p=1.337 q=70] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "glue"
+    ],
+    "doc": "<h1><code>++glue</code></h1>\n\n<p>Skip delimiter</p>\n\n<p>Parsing composer: connects an <code>++edge</code> <code>vex</code> with a following <code>++rule</code> <code>sab</code> by\nparsing the <code>++rule</code> <code>bus</code> (the delimiting symbol) and throwing out the\nresult.</p>\n\n<h2>Accepts</h2>\n\n<p><code>bus</code> is a <code>++rule</code>.</p>\n\n<p><code>sab</code> is a <code>++rule</code>.</p>\n\n<p><code>vex</code> is an <code>++edge</code>.</p>\n\n<h2>Produces</h2>\n\n\n\n<h2>Source</h2>\n\n<pre><code>++  glue                                                ::  add rule\n  ~/  %glue\n  |*  bus/rule\n  ~/  %fun\n  |*  {vex/edge sab/rule}\n  (plug vex ;~(pfix bus sab))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"200|mal|bon\" ;~((glue bar) dem sym sym))\n[q=200 7.102.829 7.237.474]\n&gt; `[@u @tas @tas]`(scan \"200|mal|bon\" ;~((glue bar) dem sym sym))\n[200 %mal %bon]\n&gt;  (scan \"200|;|bon\" ;~((glue bar) dem sem sym))\n[q=200 ~~~3b. 7.237.474]\n&gt;  (scan \"200.;.bon\" ;~((glue dot) dem sem sym))\n[q=200 ~~~3b. 7.237.474]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "less"
+    ],
+    "doc": "<h1><code>++less</code></h1>\n\n<p>Parse unless</p>\n\n<p>Parsing composer: if an <code>++edge</code> <code>vex</code> reflects a success, fail. Otherwise,\nconnect <code>vex</code> with the following <code>++rule</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>sab</code> is a <code>++rule</code>.</p>\n\n<p><code>vex</code> is an <code>++edge</code>.</p>\n\n<h2>Produces</h2>\n\n\n\n<h2>Source</h2>\n\n<pre><code>++  less                                                ::  no first and second\n  |*  {vex/edge sab/rule}\n  ?~  q.vex\n    =+  roq=(sab)\n    [p=(last p.vex p.roq) q=q.roq]\n  (fail +&lt;.sab)\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"sas-/lo\" (star ;~(less lus bar prn)))\n\"sas-/lo\"\n&gt; (scan \"sas-/l+o\" (star ;~(less lus bar prn)))\n! {1 8}\n! exit\n&gt; (scan \"sas|-/lo\" (star ;~(less lus bar prn)))\n! {1 5}\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "pfix"
+    ],
+    "doc": "<h1><code>++pfix</code></h1>\n\n<p>Discard first rule</p>\n\n<p>Parsing composer: connects an <code>++edge</code> <code>vex</code> with two subsequent <code>++rule</code>s,\nignoring the result of the first and producing the result of the second.</p>\n\n<h2>Accepts</h2>\n\n<p><code>vex</code> is an edge.</p>\n\n<h2>Produces</h2>\n\n\n\n<h2>Source</h2>\n\n<pre><code>++  pfix                                                ::  discard first rule\n  ~/  %pfix\n  (comp |*({a/* b/*} b))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@t`(scan \"%him\" ;~(pfix cen sym))\n'him'\n&gt; (scan \"+++10\" ;~(pfix (star lus) dem))\nq=10\n</code></pre>"
+  },
+  {
+    "keys": [
+      "plug"
+    ],
+    "doc": "<h1><code>++plug</code></h1>\n\n<p>Parse to tuple</p>\n\n<p>Parsing composer: connects an <code>++edge</code> <code>vex</code> with a following <code>++rule</code> <code>sab</code>, producing\na cell of both the results. See also: the monad applicator ;\\~ for a\nmore detailed explanation.</p>\n\n<h2>Accepts</h2>\n\n<p><code>sab</code> is a <code>++rule</code>.</p>\n\n<p><code>vex</code> is an <code>++edge</code>.</p>\n\n<h2>Produces</h2>\n\n\n\n<h2>Source</h2>\n\n<pre><code>++  plug                                                ::  first then second\n  ~/  %plug\n  |*  {vex/edge sab/rule}\n  ?~  q.vex\n    vex\n  =+  yit=(sab q.u.q.vex)\n  =+  yur=(last p.vex p.yit)\n  ?~  q.yit\n    [p=yur q=q.yit]\n  [p=yur q=[~ u=[p=[p.u.q.vex p.u.q.yit] q=q.u.q.yit]]]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"1..20\" ;~(plug dem dot dot dem))\n[q=1 ~~~. ~~~. q=20]\n&gt; (scan \"moke/~2014.1.1\" ;~(plug sym fas nuck:so))\n[1.701.539.693 ~~~2f. [% p=[p=~.da q=170.141.184.500.766.106.671.844.917.172.921.958.400]]]\n&gt; ;;(,[@tas @t ~ %da @da] (scan \"moke/~2014.1.1\" ;~(plug sym fas nuck:so)))\n[%moke '/' ~ %da ~2014.1.1]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "pose"
+    ],
+    "doc": "<h1><code>++pose</code></h1>\n\n<p>Parse options</p>\n\n<p>Parsing composer: if <code>vex</code> reflects a failure, connect it with the\nfollowing rule <code>sab</code>. See also: the monad applicator ;\\~</p>\n\n<h2>Accepts</h2>\n\n<p><code>sab</code> is a <code>++rule</code>.</p>\n\n<p><code>vex</code> is an <code>++edge</code>.</p>\n\n<h2>Produces</h2>\n\n\n\n<h2>Source</h2>\n\n<pre><code>++  pose                                                ::  first or second\n  ~/  %pose\n  |*  {vex/edge sab/rule}\n  ?~  q.vex\n    =+  roq=(sab)\n    [p=(last p.vex p.roq) q=q.roq]\n  vex\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@t`(scan \"+\" ;~(pose lus tar cen))\n'+'\n&gt; `@t`(scan \"*\" ;~(pose lus tar cen))\n'*'\n&gt; `@t`(scan \"%\" ;~(pose lus tar cen))\n'%'\n&gt; `@t`(scan \"-\" ;~(pose lus tar cen))\n! {1 1}\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sfix"
+    ],
+    "doc": "<h1><code>++sfix</code></h1>\n\n<p>Discard second rule</p>\n\n<p>Parsing composer: connects <code>++edge</code>s <code>vex</code> with two subsequent <code>++rule</code>s returning the\nresult of the first and discarding the result of the second.</p>\n\n<h2>Accepts</h2>\n\n<p><code>a</code> is the result of parsing the first <code>++rule</code>.</p>\n\n<p><code>b</code> is the result of of parsing the second <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n\n\n<h2>Source</h2>\n\n<pre><code>++  sfix                                                ::  discard second rule\n  ~/  %sfix\n  (comp |*({a/* b/*} a))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@t`(scan \"him%\" ;~(sfix sym cen))\n'him'\n&gt; (scan \"10+++\" ;~(sfix dem (star lus)))\nq=10\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "bass"
+    ],
+    "doc": "<h1><code>++bass</code></h1>\n\n<p>Parser modifier: LSB\nordered <code>++list</code> as atom of a <code>++base</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>wuc</code> is an atom.</p>\n\n<p><code>tyd</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bass\n  |*  {wuc/@ tyd/rule}\n  %+  cook\n    |=  waq/(list @)\n    %+  roll\n      waq\n    =|({p/@ q/@} |.((add p (mul wuc q))))\n  tyd\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"123\" (bass 10 (star dit)))\nq=123\n&gt; (scan \"123\" (bass 8 (star dit)))\nq=83\n&gt; `@ub`(scan \"123\" (bass 8 (star dit)))\n0b101.0011\n</code></pre>"
+  },
+  {
+    "keys": [
+      "boss"
+    ],
+    "doc": "<h1><code>++boss</code></h1>\n\n<p>Parser modifier: LSB</p>\n\n<p>Ordered <code>++list</code> as atom of a <code>++base</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>wuc</code> is an atom.</p>\n\n<p><code>tyd</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  boss\n  |*  {wuc/@ tyd/rule}\n  %+  cook\n    |=  waq/(list @)\n    %+  reel\n      waq\n    =|({p/@ q/@} |.((add p (mul wuc q))))\n  tyd\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"123\" (boss 10 (star dit)))\nq=321\n&gt; `@t`(scan \"bam\" (boss 256 (star alp)))\n'bam'\n&gt; `@ux`(scan \"bam\" (boss 256 (star alp)))\n0x6d.6162\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cold"
+    ],
+    "doc": "<h1><code>++cold</code></h1>\n\n<p>Replace with constant</p>\n\n<p>Parser modifier. Accepts a <code>++rule</code> <code>sef</code> and produces a parser that\nproduces a constant <code>cus</code>, assuming <code>sef</code> is successful.</p>\n\n<h2>Accepts</h2>\n\n<p><code>cus</code> is a constant noun.</p>\n\n<p><code>sef</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An <code>++edge</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cold                                                ::  replace w+ constant\n  ~/  %cold\n  |*  {cus/* sef/rule}\n  ~/  %fun\n  |=  tub/nail\n  =+  vex=(sef tub)\n  ?~  q.vex\n    vex\n  [p=p.vex q=[~ u=[p=cus q=q.u.q.vex]]]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; ((cold %foo (just 'a')) [[1 1] \"abc\"])\n    [p=[p=1 q=2] q=[~ u=[p=%foo q=[p=[p=1 q=2] q=\"bc\"]]]]\n    &gt; ((cold %foo (just 'a')) [[1 1] \"bc\"])\n    [p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cook"
+    ],
+    "doc": "<h1><code>++cook</code></h1>\n\n<p>Apply gate</p>\n\n<p>Parser modifier. Produces a parser that takes a (successful) result of a\n<code>++rule</code> <code>sef</code> and slams it through <code>poq</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>poq</code> is a gate.</p>\n\n<p><code>sef</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cook                                                ::  apply gate\n  ~/  %cook\n  |*  {poq/$-(* *) sef/rule}\n  ~/  %fun\n  |=  tub/nail\n  =+  vex=(sef tub)\n  ?~  q.vex\n    vex\n  [p=p.vex q=[~ u=[p=(poq p.u.q.vex) q=q.u.q.vex]]]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; ((cook ,@ud (just 'a')) [[1 1] \"abc\"])\n    [p=[p=1 q=2] q=[~ u=[p=97 q=[p=[p=1 q=2] q=\"bc\"]]]]\n    &gt; ((cook ,@tas (just 'a')) [[1 1] \"abc\"])\n    [p=[p=1 q=2] q=[~ u=[p=%a q=[p=[p=1 q=2] q=\"bc\"]]]]\n    &gt; ((cook |=(a=@ +(a)) (just 'a')) [[1 1] \"abc\"])\n    [p=[p=1 q=2] q=[~ u=[p=98 q=[p=[p=1 q=2] q=\"bc\"]]]]\n    &gt; ((cook |=(a=@ `@t`+(a)) (just 'a')) [[1 1] \"abc\"])\n    [p=[p=1 q=2] q=[~ u=[p='b' q=[p=[p=1 q=2] q=\"bc\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "easy"
+    ],
+    "doc": "<h1><code>++easy</code></h1>\n\n<p>Always parse</p>\n\n<p>Parser generator. Produces a parser that succeeds with given noun <code>huf</code>\nwithout consuming any text.</p>\n\n<h2>Accepts</h2>\n\n<p><code>huf</code> is a noun.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  easy                                                ::  always parse\n  ~/  %easy\n  |*  huf=*\n  ~/  %fun\n  |=  tub=nail\n  ^-  (like ,_huf)\n  [p=p.tub q=[~ u=[p=huf q=tub]]]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((easy %foo) [[1 1] \"abc\"])\n[p=[p=1 q=1] q=[~ [p=%foo q=[p=[p=1 q=1] q=\"abc\"]]]]\n&gt; ((easy %foo) [[1 1] \"bc\"])\n[p=[p=1 q=1] q=[~ [p=%foo q=[p=[p=1 q=1] q=\"bc\"]]]]\n&gt; ((easy 'a') [[1 1] \"bc\"])\n[p=[p=1 q=1] q=[~ [p='a' q=[p=[p=1 q=1] q=\"bc\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "full"
+    ],
+    "doc": "<h1><code>++full</code></h1>\n\n<p>Parse to end</p>\n\n<p>Parser modifier. Accepts a <code>++rule</code> <code>sef</code>, and produces a parser that succeeds only\nwhen the of <code>tub</code> is fully consumed using <code>sef</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>sef</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  full                                                :: parse to end \n  |*  sef=_rule\n  |=  tub=nail\n  =+  vex=(sef tub)\n  ?~(q.vex vex ?:(=(~ q.q.u.q.vex) vex [p=p.vex q=~]))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((full (just 'a')) [[1 1] \"ab\"])\n[p=[p=1 q=2] q=~]\n&gt; ((full (jest 'ab')) [[1 1] \"ab\"])\n[p=[p=1 q=3] q=[~ u=[p='ab' q=[p=[p=1 q=3] q=\"\"]]]]\n&gt; ((full ;~(plug (just 'a') (just 'b'))) [[1 1] \"ab\"])\n[p=[p=1 q=3] q=[~ u=[p=[~~a ~~b] q=[p=[p=1 q=3] q=\"\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "funk"
+    ],
+    "doc": "<h1><code>++funk</code></h1>\n\n<p>Add to tape</p>\n\n<p>Parser modifier: prepend text to <code>++tape</code> before applying parser.</p>\n\n<h2>Accepts</h2>\n\n<p><code>pre</code> is a <code>++tape</code></p>\n\n<p><code>sef</code> is a <code>++rule</code></p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  funk                                                ::  add to tape first\n  |*  {pre/tape sef/rule}\n  |=  tub/nail\n  (sef p.tub (weld pre q.tub))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((funk \"abc prefix-\" (jest 'abc')) [[1 1] \"to be parsed\"])\n[p=[p=1 q=4] q=[~ [p='abc' q=[p=[p=1 q=4] q=\" prefix-to be parsed\"]]]]\n&gt; ((funk \"parse\" (just 'a')) [[1 4] \" me\"])\n[p=[p=1 q=4] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "here"
+    ],
+    "doc": "<h1><code>++here</code></h1>\n\n<p>Place-based apply</p>\n\n<p>Parser modifier. Similar to <code>++cook</code> in that it produces a parser that takes a\n(successful) result of <code>sef</code> and slams it through <code>hez</code>. <code>hez</code> accepts a\n<code>++pint</code> <code>a</code> and a noun <code>b</code>, which is what the parser parsed.</p>\n\n<h2>Accepts</h2>\n\n<p><code>hez</code> is a gate.</p>\n\n<p><code>sef</code> is a <code>++rule</code></p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  here                                                ::  place-based apply\n  ~/  %here\n  |*  {hez/_|=({a/pint b/*} [a b]) sef/rule}\n  ~/  %fun\n  |=  tub/nail\n  =+  vex=(sef tub)\n  ?~  q.vex\n    vex\n  [p=p.vex q=[~ u=[p=(hez [p.tub p.q.u.q.vex] p.u.q.vex) q=q.u.q.vex]]]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"abc\" (star alf))\n\"abc\"\n&gt; (scan \"abc\" (here |*(^ +&lt;) (star alf)))\n[[[p=1 q=1] p=1 q=4] \"abc\"]\n&gt; (scan \"abc\" (star (here |*(^ +&lt;) alf)))\n~[[[[p=1 q=1] p=1 q=2] ~~a] [[[p=1 q=2] p=1 q=3] ~~b] [[[p=1 q=3] p=1 q=4] ~~c]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "ifix"
+    ],
+    "doc": "<h1><code>++ifix</code></h1>\n\n<p>Infix</p>\n\n<p>Parser modifier: surround with pair of <code>++rule</code>s, the output of which is\ndiscarded.</p>\n\n<h2>Accepts</h2>\n\n<p><code>fel</code> is a pair of <code>++rule</code>s.</p>\n\n<p><code>hof</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  ifix\n  |*  {fel/{rule rule} hof/rule}\n  ~!  +&lt;\n  ~!  +&lt;:-.fel\n  ~!  +&lt;:+.fel\n  ;~(pfix -.fel ;~(sfix hof +.fel))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"-40-\" (ifix [hep hep] dem))\nq=40\n&gt; (scan \"4my4\" (ifix [dit dit] (star alf)))\n\"my\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "jest"
+    ],
+    "doc": "<h1><code>++jest</code></h1>\n\n<p>Match a cord</p>\n\n<p>Match and consume a cord.</p>\n\n<h2>Accepts</h2>\n\n<p><code>daf</code> is a <code>@t</code>.</p>\n\n<h2>Produces</h2>\n\n<p>An <code>++edge</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  jest                                                ::  match a cord\n  |=  daf/@t\n  |=  tub/nail\n  =+  fad=daf\n  |-  ^-  (like @t)\n  ?:  =(`@`0 daf)\n    [p=p.tub q=[~ u=[p=fad q=tub]]]\n  ?:  |(?=($~ q.tub) !=((end 3 1 daf) i.q.tub))\n    (fail tub)\n  $(p.tub (lust i.q.tub p.tub), q.tub t.q.tub, daf (rsh 3 1 daf))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((jest 'abc') [[1 1] \"abc\"])\n[p=[p=1 q=4] q=[~ [p='abc' q=[p=[p=1 q=4] q=\"\"]]]]\n&gt; (scan \"abc\" (jest 'abc'))\n'abc'\n&gt; (scan \"abc\" (jest 'acb'))\n! {1 2}\n! 'syntax-error'\n! exit\n&gt; ((jest 'john doe') [[1 1] \"john smith\"])\n[p=[p=1 q=6] q=~]\n&gt; ((jest 'john doe') [[1 1] \"john doe\"])\n[p=[p=1 q=9] q=[~ [p='john doe' q=[p=[p=1 q=9] q=\"\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "just"
+    ],
+    "doc": "<h1><code>++just</code></h1>\n\n<p>Match a char</p>\n\n<p>Match and consume a single character.</p>\n\n<h2>Accepts</h2>\n\n<p><code>daf</code> is a <code>++char</code></p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  just                                                ::  XX redundant, jest\n  ~/  %just                                             ::  match a char\n  |=  daf/char\n  ~/  %fun\n  |=  tub/nail\n  ^-  (like char)\n  ?~  q.tub\n    (fail tub)\n  ?.  =(daf i.q.tub)\n    (fail tub)\n  (next tub)\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((just 'a') [[1 1] \"abc\"])\n[p=[p=1 q=2] q=[~ [p=~~a q=[p=[p=1 q=2] q=\"bc\"]]]]\n&gt; (scan \"abc\" (just 'a'))\n! {1 2}\n! 'syntax-error'\n! exit\n&gt; (scan \"a\" (just 'a'))\n~~a\n&gt; (scan \"%\" (just '%'))\n~~~25.\n</code></pre>"
+  },
+  {
+    "keys": [
+      "knee"
+    ],
+    "doc": "<h1><code>++knee</code></h1>\n\n<p>Recursive parsers</p>\n\n<p>Used for recursive parsers, which would otherwise be infinite when\ncompiled.</p>\n\n<h2>Accepts</h2>\n\n<p><code>gar</code> is a noun.</p>\n\n<p><code>sef</code> is a gate that accepts a <code>++rule</code></p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  knee                                                ::  callbacks\n  |*  {gar/* sef/_|.(*rule)}\n  |=  tub/nail\n  ^-  (like _gar)\n  ((sef) tub)\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; |-(;~(plug prn ;~(pose $ (easy ~))))\n! rest-loop\n! exit\n&gt; |-(;~(plug prn ;~(pose (knee *tape |.(^$)) (easy ~))))\n&lt; 1.obo\n  [ c=c=tub=[p=[p=@ud q=@ud] q=\"\"]\n      b\n    &lt; 1.bes\n      [ c=tub=[p=[p=@ud q=@ud] q=\"\"]\n        b=&lt;1.tnv [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.ktu [daf=@tD &lt;414.fvk 101.jzo 1.ypj %164&gt;]&gt;]&gt;\n        a=&lt;1.fvg [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.khu [[les=@ mos=@] &lt;414.fvk 101.jzo 1.ypj %164&gt;]&gt;]&gt;\n        v=&lt;414.fvk 101.jzo 1.ypj %164&gt;\n      ]\n    &gt;\n      a\n    ... 450 lines omitted ...\n  ]\n&gt;\n&gt; (scan \"abcd\" |-(;~(plug prn ;~(pose (knee *tape |.(^$)) (easy ~)))))\n[~~a \"bcd\"]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mask"
+    ],
+    "doc": "<h1><code>++mask</code></h1>\n\n<p>Match char</p>\n\n<p>Parser generator. Matches the next character if it is in a list of\ncharacters.</p>\n\n<h2>Accepts</h2>\n\n<p><code>bud</code> is a list of <code>++char</code></p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mask                                                ::  match char in set\n  ~/  %mask\n  |=  bud/(list char)\n  ~/  %fun\n  |=  tub/nail\n  ^-  (like char)\n  ?~  q.tub\n    (fail tub)\n  ?.  (lien bud |=(a/char =(i.q.tub a)))\n    (fail tub)\n  (next tub)\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"a\" (mask \"cba\"))\n~~a\n&gt; ((mask \"abc\") [[1 1] \"abc\"])\n[p=[p=1 q=2] q=[~ [p=~~a q=[p=[p=1 q=2] q=\"bc\"]]]]\n&gt; ((mask \"abc\") [[1 1] \"bbc\"])\n[p=[p=1 q=2] q=[~ [p=~~b q=[p=[p=1 q=2] q=\"bc\"]]]]\n&gt; ((mask \"abc\") [[1 1] \"dbc\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "more"
+    ],
+    "doc": "<h1><code>++more</code></h1>\n\n<p>Parse list with delimiter</p>\n\n<p>Parser modifier: Parse a list of matches using a delimiter <code>++rule</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>bus</code> is a <code>++rule</code>.</p>\n\n<p><code>fel</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  more\n  |*  {bus/rule fel/rule}\n  ;~(pose (most bus fel) (easy ~))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"\" (more ace dem))\n~\n&gt; (scan \"40 20\" (more ace dem))\n[q=40 ~[q=20]]\n&gt; (scan \"40 20 60 1 5\" (more ace dem))\n[q=40 ~[q=20 q=60 q=1 q=5]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "most"
+    ],
+    "doc": "<h1><code>++most</code></h1>\n\n<p>Parse list of at least one match</p>\n\n<p>Parser modifier: parse a <code>++list</code> of at least one match using a delimiter <code>++rule</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>bus</code> is a <code>++rule</code>.</p>\n\n<p><code>fel</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  most\n  |*  {bus/rule fel/rule}\n  ;~(plug fel (star ;~(pfix bus fel)))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"40 20\" (most ace dem))\n[q=40 ~[q=20]]\n&gt; (scan \"40 20 60 1 5\" (most ace dem))\n[q=40 ~[q=20 q=60 q=1 q=5]]\n&gt; (scan \"\" (most ace dem))\n! {1 1}\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "next"
+    ],
+    "doc": "<h1><code>++next</code></h1>\n\n<p>Consume char</p>\n\n<p>Consume any character, producing it as a result.</p>\n\n<h2>Accepts</h2>\n\n<p><code>tub</code> is a <code>++nail</code></p>\n\n<h2>Produces</h2>\n\n<p>An <code>++edge</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  next                                                ::  consume a char\n  |=  tub/nail\n  ^-  (like char)\n  ?~  q.tub\n    (fail tub)\n  =+  zac=(lust i.q.tub p.tub)\n  [zac [~ i.q.tub [zac t.q.tub]]]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (next [[1 1] \"ebc\"])\n[p=[p=1 q=2] q=[~ [p=~~e q=[p=[p=1 q=2] q=\"bc\"]]]] \n&gt; (next [[1 1] \"john jumps jones\"])\n[p=[p=1 q=2] q=[~ [p=~~j q=[p=[p=1 q=2] q=\"ohn jumps jones\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "plus"
+    ],
+    "doc": "<h1><code>++plus</code></h1>\n\n<p>List of at least one match.</p>\n\n<p>Parser modifier: parse <code>++list</code> of at least one match.</p>\n\n<h2>Accepts</h2>\n\n<p><code>fel</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  plus  |*(fel/rule ;~(plug fel (star fel)))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"&gt;&gt;&gt;&gt;\" (cook lent (plus gar)))\n4\n&gt; (scan \"-  - \" (plus ;~(pose ace hep)))\n[~~- \"  - \"]\n&gt; `tape`(scan \"-  - \" (plus ;~(pose ace hep)))\n\"-  - \"\n&gt; `(pole ,@t)`(scan \"-  - \" (plus ;~(pose ace hep)))\n['-' [' ' [' ' ['-' [' ' ~]]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sear"
+    ],
+    "doc": "<h1><code>++sear</code></h1>\n\n<p>Conditional <code>++cook</code></p>\n\n<p>Conditional <code>++cook</code>. Slams the result through a gate that produces\na unit; if that unit is empty, fail.</p>\n\n<h2>Accepts</h2>\n\n<p><code>tub</code> is a <code>++nail</code>.</p>\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  sear                                                ::  conditional cook\n  |*  {pyq/$-(* (unit)) sef/rule}\n  |=  tub/nail\n  =+  vex=(sef tub)\n  ?~  q.vex\n    vex\n  =+  gey=(pyq p.u.q.vex)\n  ?~  gey\n    [p=p.vex q=~]\n  [p=p.vex q=[~ u=[p=u.gey q=q.u.q.vex]]]\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((sear |=(a/* ?@(a (some a) ~)) (just `a`)) [[1 1] \"abc\"])\n[p=[p=1 q=2] q=[~ u=[p=97 q=[p=[p=1 q=2] q=\"bc\"]]]]\n&gt; ((sear |=(* ~) (just 'a')) [[1 1] \"abc\"])\n[p=[p=1 q=2] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "shim"
+    ],
+    "doc": "<h1><code>++shim</code></h1>\n\n<p>Char in range</p>\n\n<p>Match characters (<code>++char</code>) within a range.</p>\n\n<h2>Accepts</h2>\n\n<p><code>les</code> is an atom.</p>\n\n<p><code>mos</code> is an atom.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  shim                                                ::  match char in range\n  ~/  %shim\n  |=  {les/@ mos/@}\n  ~/  %fun\n  |=  tub/nail\n  ^-  (like char)\n  ?~  q.tub\n    (fail tub)\n  ?.  ?&amp;((gte i.q.tub les) (lte i.q.tub mos))\n    (fail tub)\n  (next tub)\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((shim 'a' 'z') [[1 1] \"abc\"])\n[p=[p=1 q=2] q=[~ [p=~~a q=[p=[p=1 q=2] q=\"bc\"]]]]\n&gt; ((shim 'a' 'Z') [[1 1] \"abc\"])\n[p=[p=1 q=1] q=~]\n&gt; ((shim 'a' 'Z') [[1 1] \"Abc\"])\n[p=[p=1 q=2] q=[~ [p=~~~41. q=[p=[p=1 q=2] q=\"bc\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "slug"
+    ],
+    "doc": "<h1><code>++slug</code></h1>\n\n<p>Use gate to parse delimited list</p>\n\n<p>Parser modifier: By composing with a gate, parse a delimited <code>++list</code> of\nmatches.</p>\n\n<h2>Accepts</h2>\n\n<p><code>bus</code> is a <code>++rule</code>.</p>\n\n<p><code>fel</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  slug\n  |*  raq/_|*({a/* b/*} [a b])\n  |*  {bus/rule fel/rule}\n  ;~((comp raq) fel (stir +&lt;+.raq raq ;~(pfix bus fel)))\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"20+5+110\" ((slug add) lus dem))\n135\n&gt; `@t`(scan \"a b c\" ((slug |=(a/[@ @t] (cat 3 a))) ace alp))\n'abc'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "stag"
+    ],
+    "doc": "<h1><code>++stag</code></h1>\n\n<p>Add label</p>\n\n<p>Add a label to an edge parsed by a rule.</p>\n\n<h2>Accepts</h2>\n\n<p><code>gob</code> is a noun.</p>\n\n<p><code>sef</code> is a rule.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  stag                                                ::  add a label\n  ~/  %stag\n  |*  {gob/* sef/rule}\n  ~/  %fun\n  |=  tub/nail\n  =+  vex=(sef tub)\n  ?~  q.vex\n    vex\n  [p=p.vex q=[~ u=[p=[gob p.u.q.vex] q=q.u.q.vex]]]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ((stag %foo (just 'a')) [[1 1] \"abc\"])\n[p=[p=1 q=2] q=[~ u=[p=[%foo ~~a] q=[p=[p=1 q=2] q=\"bc\"]]]]\n&gt; ((stag \"xyz\" (jest 'abc')) [[1 1] \"abc\"])\n[p=[p=1 q=4] q=[~ u=[p=[\"xyz\" 'abc'] q=[p=[p=1 q=4] q=\"\"]]]]\n&gt; ((stag 10.000 (shim 0 100)) [[1 1] \"abc\"])\n[p=[p=1 q=2] q=[~ u=[p=[10.000 ~~a] q=[p=[p=1 q=2] q=\"bc\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "star"
+    ],
+    "doc": "<h1><code>++star</code></h1>\n\n<p>List of matches</p>\n\n<p>Parser modifier: parse <code>++list</code> of matches.</p>\n\n<h2>Accepts</h2>\n\n<p><code>fel</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<pre><code>++  star                                                ::  0 or more times\n  |*  fel/rule\n  (stir `(list _(wonk *fel))`~ |*({a/* b/*} [a b]) fel)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"aaaaa\" (just 'a'))\n    ! {1 2}\n    ! 'syntax-error'\n    ! exit\n    &gt; (scan \"aaaaa\" (star (just 'a')))\n    \"aaaaa\"\n    &gt; (scan \"abcdef\" (star (just 'a')))\n    ! {1 2}\n    ! 'syntax-error'\n    ! exit\n    &gt; (scan \"abcabc\" (star (jest 'abc')))\n    &lt;|abc abc|&gt;\n    &gt; (scan \"john smith\" (star (shim 0 200)))\n    \"john smith\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "stet"
+    ],
+    "doc": "<h1><code>++stet</code></h1>\n\n<p>Add faces</p>\n\n<p>Add faces <code>[p q]</code> to range-parser pairs in a list.</p>\n\n<h2>Accepts</h2>\n\n<p><code>leh</code> is a list of range-parsers.</p>\n\n<h2>Produces</h2>\n\n\n\n<h2>Source</h2>\n\n<pre><code>++  stet\n  |*  leh/(list {?(@ {@ @}) rule})\n  |-\n  ?~  leh\n    ~\n  [i=[p=-.i.leh q=+.i.leh] t=$(leh t.leh)]\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (stet (limo [[5 (just 'a')] [1 (jest 'abc')] [[1 1] (shim 0 200)] \n[[1 10] (cold %foo (just 'a'))]~]))\n~[\n  [p=5 q=&lt;1.lrk [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.nqy [daf=@tD &lt;394.imz 97.kdz 1.xlc %164&gt;]&gt;]&gt;]\n  [p=1 q=&lt;1.lrk [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.nqy [daf=@tD &lt;394.imz 97.kdz 1.xlc %164&gt;]&gt;]&gt;]\n  [p=[1 1] q=&lt;1.lrk [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.nqy [daf=@tD &lt;394.imz 97.kdz 1.xlc %164&gt;]&gt;]&gt;]\n  [p=[1 10] q=&lt;1.lrk [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.nqy [daf=@tD &lt;394.imz 97.kdz 1.xlc %164&gt;]&gt;]&gt;]\n]\n&gt; [[[1 1] (just 'a')] [[2 1] (shim 0 200)] ~]\n[ [[1 1] &lt;1.tnv [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.ktu [daf=@tD &lt;414.fvk 101.jzo 1.ypj %164&gt;]&gt;]&gt;]\n  [[2 1] &lt;1.fvg [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.khu [[les=@ mos=@] &lt;414.fvk 101.jzo 1.ypj %164&gt;]&gt;]&gt;]\n  ~\n]\n&gt; (stet (limo [[[1 1] (just 'a')] [[2 1] (shim 0 200)] ~]))\n~[\n  [p=[1 1] q=&lt;1.lrk [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.nqy [daf=@tD &lt;394.imz 97.kdz 1.xlc %164&gt;]&gt;]&gt;] \n  [p=[2 1] q=&lt;1.lrk [tub=[p=[p=@ud q=@ud] q=\"\"] &lt;1.nqy [daf=@tD &lt;394.imz 97.kdz 1.xlc %164&gt;]&gt;]&gt;]\n]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "stew"
+    ],
+    "doc": "<h1><code>++stew</code></h1>\n\n<p>Switch by first</p>\n\n<pre><code>++  stew                                                ::  switch by first char\n  ~/  %stew\n  |*  leh/(list {p/?(@ {@ @}) q/rule})                  ::  char+range keys\n  =+  ^=  wor                                           ::  range complete lth\n      |=  {ort/?(@ {@ @}) wan/?(@ {@ @})}\n      ?@  ort\n        ?@(wan (lth ort wan) (lth ort -.wan))\n      ?@(wan (lth +.ort wan) (lth +.ort -.wan))\n  =+  ^=  hel                                           ::  build parser map\n      =+  hel=`(tree _?&gt;(?=(^ leh) i.leh))`~\n      |-  ^+  hel\n      ?~  leh\n        ~\n      =+  yal=$(leh t.leh)\n      |-  ^+  hel\n      ?~  yal\n        [i.leh ~ ~]\n      ?:  (wor p.i.leh p.n.yal)\n        =+  nuc=$(yal l.yal)\n        ?&gt;  ?=(^ nuc)\n        ?:  (vor p.n.yal p.n.nuc)\n          [n.yal nuc r.yal]\n        [n.nuc l.nuc [n.yal r.nuc r.yal]]\n      =+  nuc=$(yal r.yal)\n      ?&gt;  ?=(^ nuc)\n      ?:  (vor p.n.yal p.n.nuc)\n        [n.yal l.yal nuc]\n      [n.nuc [n.yal l.yal l.nuc] r.nuc]\n  ~%  %fun  ..^$  ~\n  |=  tub/nail\n  ?~  q.tub\n    (fail tub)\n  |-\n  ?~  hel\n    (fail tub)\n  ?:  ?@  p.n.hel\n        =(p.n.hel i.q.tub)\n      ?&amp;((gte i.q.tub -.p.n.hel) (lte i.q.tub +.p.n.hel))\n    ::  (q.n.hel [(lust i.q.tub p.tub) t.q.tub])\n    (q.n.hel tub)\n  ?:  (wor i.q.tub p.n.hel)\n    $(hel l.hel)\n  $(hel r.hel)\n::\n</code></pre>\n\n\n\n<p>Parser generator. From an associative <code>++list</code> of characters or character\nranges to <code>++rule</code>s, construct a <code>++map</code>, and parse <code>++tape</code>s only\nwith <code>++rules</code> associated with a range that the <code>++tape</code>'s first character falls in.</p>"
+  },
+  {
+    "keys": [
+      "stir"
+    ],
+    "doc": "<h1><code>++stir</code></h1>\n\n<p>Parse repeatedly</p>\n\n<p>Parse with <code>++rule</code> as many times as possible, and fold over results with a\nbinary gate.</p>\n\n<h2>Accepts</h2>\n\n<p><code>rud</code> is a noun.</p>\n\n<p><code>raq</code> is a gate that takes two nouns and produces a cell.</p>\n\n<p><code>fel</code> is a rule.</p>\n\n<h2>Produces</h2>\n\n<p>A rule.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  stun                                                ::  parse several times\n  |*  {lig/{@ @} fel/rule}\n  |=  tub/nail\n  ^-  (like (list _(wonk (fel))))\n  ?:  =(0 +.lig)\n    [p.tub [~ ~ tub]]\n  =+  vex=(fel tub)\n  ?~  q.vex\n    ?:  =(0 -.lig)\n      [p.vex [~ ~ tub]]\n    vex\n  =+  ^=  wag  %=  $\n                 -.lig  ?:(=(0 -.lig) 0 (dec -.lig))\n                 +.lig  ?:(=(0 +.lig) 0 (dec +.lig))\n                 tub  q.u.q.vex\n               ==\n  ?~  q.wag\n    wag\n  [p.wag [~ [p.u.q.vex p.u.q.wag] q.u.q.wag]]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"abc\" (stir *@ add prn))\n294\n&gt; (roll \"abc\" add)\nb=294\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "rash"
+    ],
+    "doc": "<h1><code>++rash</code></h1>\n\n<p>Parse or crash</p>\n\n<p>Parse a cord with a given <code>++rule</code> and crash if the <code>++cord</code> isn't entirely\nparsed.</p>\n\n<h2>Accepts</h2>\n\n<p><code>naf</code> is an atom.</p>\n\n<p><code>sab</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>The value of the parse result, or crash.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  rash  |*({naf/@ sab/rule} (scan (trip naf) sab))   ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (rash 'I was the world in which I walked, and what I saw' (star (shim 0 200)))\n\"I was the world in which I walked, and what I saw\"\n&gt; (rash 'abc' (just 'a'))\n! {1 2}\n! 'syntax-error'\n! exit\n&gt; (rash 'abc' (jest 'abc'))\n'abc'\n`&gt; (rash 'abc' (jest 'ab'))\n! {1 3}\n! 'syntax-error'\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "rush"
+    ],
+    "doc": "<h1><code>++rush</code></h1>\n\n<p>Parse or null</p>\n\n<p>Parse a given with a given rule and produce null if the cord isn't\nentirely parsed.</p>\n\n<h2>Accepts</h2>\n\n<p><code>naf</code> is an atom.</p>\n\n<p><code>sab</code> is a rule.</p>\n\n<h2>Produces</h2>\n\n<p>The value of the parse result, or null.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  rush  |*({naf/@ sab/rule} (rust (trip naf) sab))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (rush 'I was the world in which I walked, and what I saw' (star (shim 0 200)))\n    [~ \"I was the world in which I walked, and what I saw\"]\n    &gt; (rush 'abc' (just 'a'))\n    ~\n    &gt; (rush 'abc' (jest 'abc'))\n    [~ 'abc']\n    &gt; (rush 'abc' (jest 'ac'))\n    ~\n    &gt; (rush 'abc' (jest 'ab'))\n    ~\n</code></pre>"
+  },
+  {
+    "keys": [
+      "rust"
+    ],
+    "doc": "<h1><code>++rust</code></h1>\n\n<p>Parse tape or null</p>\n\n<p>Parse a <code>++tape</code> with a given <code>++rule</code> and produce null if the <code>++tape</code> isn't\nentirely parsed.</p>\n\n<h2>Accepts</h2>\n\n<p><code>los</code> is a <code>++tape</code>.</p>\n\n<p><code>sab</code> is a <code>++rule</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>(unit ,@t)</code></p>\n\n<h2>Source</h2>\n\n<pre><code>++  rust  |*  {los/tape sab/rule}\n          =+  vex=((full sab) [[1 1] los])\n          ?~(q.vex ~ [~ u=p.u.q.vex])\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (rust \"I was the world in which I walked, and what I saw\" (star (shim 0 200)))\n    [~ \"I was the world in which I walked, and what I saw\"]\n    &gt; (rust \"Or heard or felt came not but from myself;\" (star (shim 0 200)))\n    [~ \"Or heard or felt came not but from myself;\"]\n    &gt; (rust \"And there I found myself more truly and more strange.\" (jest 'And there I'))\n    ~\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "ace"
+    ],
+    "doc": "<h1><code>++ace</code></h1>\n\n<p>Parse space</p>\n\n<p>Parses ASCII character 32, space.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  ace  (just ' ')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \" \" ace)\n~~. \n&gt; `cord`(scan \" \" ace)\n' '\n&gt; (ace [[1 1] \" \"])\n[p=[p=1 q=2] q=[~ [p=~~. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (ace [[1 1] \" abc \"])\n[p=[p=1 q=2] q=[~ [p=~~. q=[p=[p=1 q=2] q=\"abc \"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "bar"
+    ],
+    "doc": "<h1><code>++bar</code></h1>\n\n<p>Parse vertical bar</p>\n\n<p>Parses ASCII character 124, the vertical bar.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bar  (just '|')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"|\" bar)\n~~~7c. \n&gt; `cord`(scan \"|\" bar)\n'|'\n&gt; (bar [[1 1] \"|\"])\n[p=[p=1 q=2] q=[~ [p=~~~7c. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (bar [[1 1] \"|=\"])\n[p=[p=1 q=2] q=[~ [p=~~~7c. q=[p=[p=1 q=2] q=\"=\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "bas"
+    ],
+    "doc": "<h1><code>++bas</code></h1>\n\n<p>Parse backslash</p>\n\n<p>Parses ASCII character 92, the backslash. Note the extra `` in the calling of\n<code>bas</code> with <a href=\"/docs/hoon/library/2ec#++just\"><code>++just</code></a> is to escape the escape\ncharacter, ``.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bas  (just '\\\\')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"\\\\\" bas)\n~~~5c.\n&gt; `cord`(scan \"\\\\\" bas)\n'\\'\n&gt; (bas [[1 1] \"\\\"])\n~ &lt;syntax error at [1 18]&gt;\n&gt; (bas [[1 1] \"\\\\\"])\n[p=[p=1 q=2] q=[~ [p=~~~5c. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (bas [[1 1] \"\\\"\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "buc"
+    ],
+    "doc": "<h1><code>++buc</code></h1>\n\n<p>Parse dollar sign</p>\n\n<p>Parses ASCII character 36, the dollar sign.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  buc  (just '$')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"$\" buc)\n~~~24.\n&gt; `cord`(scan \"$\" buc)\n'$'\n&gt; (buc [[1 1] \"$\"])\n[p=[p=1 q=2] q=[~ [p=~~~24. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (buc [[1 1] \"$%\"])\n[p=[p=1 q=2] q=[~ [p=~~~24. q=[p=[p=1 q=2] q=\"%\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cab"
+    ],
+    "doc": "<h1><code>++cab</code></h1>\n\n<p>Parse underscore</p>\n\n<p>Parses ASCII character 95, the underscore.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cab  (just '_')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"_\" cab)\n~~~5f.\n&gt; `cord`(scan \"_\" cab)\n'_'\n&gt; (cab [[1 1] \"_\"])\n[p=[p=1 q=2] q=[~ [p=~~~5f. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (cab [[1 1] \"|_\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cen"
+    ],
+    "doc": "<h1><code>++cen</code></h1>\n\n<p>Parses percent sign</p>\n\n<p>Parses ASCII character 37, the percent sign.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cen  (just '%')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"%\" cen)\n~~~25.\n&gt; `cord`(scan \"%\" cen)\n'%'\n&gt; (cen [[1 1] \"%\"])\n[p=[p=1 q=2] q=[~ [p=~~~25. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (cen [[1 1] \"%^\"])\n[p=[p=1 q=2] q=[~ [p=~~~25. q=[p=[p=1 q=2] q=\"^\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "col"
+    ],
+    "doc": "<h1><code>++col</code></h1>\n\n<p>Parse colon</p>\n\n<p>Parses ASCII character 58, the colon</p>\n\n<h2>Source</h2>\n\n<pre><code>++  col  (just ':')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \":\" col)\n~~~3a.\n&gt; `cord`(scan \":\" col)\n':'\n&gt; (col [[1 1] \":\"])\n[p=[p=1 q=2] q=[~ [p=~~~3a. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (col [[1 1] \":-\"])\n[p=[p=1 q=2] q=[~ [p=~~~3a. q=[p=[p=1 q=2] q=\"-\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "com"
+    ],
+    "doc": "<h1><code>++com</code></h1>\n\n<p>Parse comma</p>\n\n<p>Parses ASCII character 44, the comma.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  com  (just ',')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \",\" com)\n~~~2c.\n&gt; `cord`(scan \",\" com)\n','\n&gt; (com [[1 1] \",\"])\n[p=[p=1 q=2] q=[~ [p=~~~2c. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (com [[1 1] \"not com\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "doq"
+    ],
+    "doc": "<h1><code>++doq</code></h1>\n\n<p>Parse double quote</p>\n\n<p>Parses ASCII character 34, the double quote.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  doq  (just '\"')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"\\\"\" doq)\n~~~22.\n&gt; `cord`(scan \"\\\"\" doq)\n'\"'\n&gt; (doq [[1 1] \"\\\"\"])\n[p=[p=1 q=2] q=[~ [p=~~~22. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (doq [[1 1] \"not successfully parsed\"])\n[p=[p=1 q=1] q=~]\n&gt; (scan \"see?\" doq)\n! {1 1}\n! 'syntax-error'\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dot"
+    ],
+    "doc": "<h1><code>++dot</code></h1>\n\n<p>Parse period</p>\n\n<p>Parses ASCII character 46, the period.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  dot  (just '.')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \".\" dot)\n~~~.\n&gt; `cord`(scan \".\" dot)\n'.'\n&gt; (dot [[1 1] \".\"])\n[p=[p=1 q=2] q=[~ [p=~~~. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (dot [[1 1] \".^\"])\n[p=[p=1 q=2] q=[~ [p=~~~. q=[p=[p=1 q=2] q=\"^\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "fas"
+    ],
+    "doc": "<h1><code>++fas</code></h1>\n\n<p>Parse forward slash</p>\n\n<p>Parses ASCII character 47, the forward slash.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  fas  (just '/')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"/\" fas)\n~~~2f.\n&gt; `cord`(scan \"/\" fas)\n'/'\n&gt; (fas [[1 1] \"/\"])\n[p=[p=1 q=2] q=[~ [p=~~~2f. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (fas [[1 1] \"|/\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gal"
+    ],
+    "doc": "<h1><code>++gal</code></h1>\n\n<p>Parse less-than sign</p>\n\n<p>Parses ASCII character 60, the less-than sign.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gal  (just '&lt;')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"&lt;\" gal)\n~~~3c.\n&gt; `cord`(scan \"&lt;\" gal)\n'&lt;'\n&gt; (gal [[1 1] \"&lt;\"])\n[p=[p=1 q=2] q=[~ [p=~~~3c. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (gal [[1 1] \"&lt;+\"])\n[p=[p=1 q=2] q=[~ [p=~~~3c. q=[p=[p=1 q=2] q=\"+\"]]]]\n&gt; (gal [[1 1] \"+&lt;\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gar"
+    ],
+    "doc": "<h1><code>++gar</code></h1>\n\n<p>Parse greater-than sign</p>\n\n<p>Parses ASCII character 62, the greater-than sign.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gar  (just '&gt;')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"&gt;\" gar)\n~~~3e.\n&gt; `cord`(scan \"&gt;\" gar)\n'&gt;'\n&gt; (gar [[1 1] \"&gt;\"])\n[p=[p=1 q=2] q=[~ [p=~~~3e. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (gar [[1 1] \"=&gt;\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "hax"
+    ],
+    "doc": "<h1><code>++hax</code></h1>\n\n<p>Parse number sign</p>\n\n<p>Parses ASCII character 35, the number sign.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  hax  (just '#')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"#\" hax)\n~~~23.\n&gt; `cord`(scan \"#\" hax)\n'#'\n&gt; (hax [[1 1] \"#\"])\n[p=[p=1 q=2] q=[~ [p=~~~23. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (hax [[1 1] \"#!\"])\n[p=[p=1 q=2] q=[~ [p=~~~23. q=[p=[p=1 q=2] q=\"!\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "hep"
+    ],
+    "doc": "<h1><code>++hep</code></h1>\n\n<p>Parse hyphen</p>\n\n<p>Parses ASCII character 45, the hyphen.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  hep  (just '-')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"-\" hep)\n~~-\n&gt; `cord`(scan \"-\" hep)\n'-'\n&gt; (hep [[1 1] \"-\"])\n[p=[p=1 q=2] q=[~ [p=~~- q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (hep [[1 1] \":-\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "kel"
+    ],
+    "doc": "<h1><code>++kel</code></h1>\n\n<p>Parse left curley bracket</p>\n\n<p>Parses ASCII character 123, the left curly bracket. Note that <code>{</code>\n(<code>kel</code>) and <code>}</code> (<code>ker</code>) open and close a Hoon expression for Hoon string\ninterpolation. To parse either of them, they must be escaped.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  kel  (just '{')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"\\{\" kel)\n~~~7b.\n&gt; `cord`(scan \"\\{\" kel)\n'{'\n&gt; (kel [[1 1] \"\\{\"])\n[p=[p=1 q=2] q=[~ [p=~~~7b. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (kel [[1 1] \" \\{\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "ker"
+    ],
+    "doc": "<h1><code>++ker</code></h1>\n\n<p>Parse right curley bracket</p>\n\n<p>Parses ASCII character 125, the right curly bracket. Note that <code>{</code>\n(<code>kel</code>) and <code>}</code> (<code>ker</code>) open and close a Hoon expression for Hoon string\ninterpolation. To parse either of them, they must be escaped.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  ker  (just '}')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"}\" ker)\n~~~7d.\n&gt; `cord`(scan \"}\" ker)\n'}'\n&gt; (ker [[1 1] \"}\"])\n[p=[p=1 q=2] q=[~ [p=~~~7d. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (ker [[1 1] \"\\{}\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "ket"
+    ],
+    "doc": "<h1><code>++ket</code></h1>\n\n<p>Parse caret</p>\n\n<p>Parses ASCII character 94, the caret.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  ket  (just '^')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"^\" ket)\n~~~5e.\n&gt; `cord`(scan \"^\" ket)\n'^'\n&gt; (ket [[1 1] \"^\"])\n[p=[p=1 q=2] q=[~ [p=~~~5e. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (ket [[1 1] \".^\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "lus"
+    ],
+    "doc": "<h1><code>++lus</code></h1>\n\n<p>Parse plus sign</p>\n\n<p>Parses ASCII character 43, the plus sign.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  lus  (just '+')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"+\" lus)\n    ~~~2b.\n    &gt; `cord`(scan \"+\" lus)\n    '+'\n    &gt; (lus [[1 1] \"+\"])\n    [p=[p=1 q=2] q=[~ [p=~~~2b. q=[p=[p=1 q=2] q=\"\"]]]]\n    &gt; (lus [[1 1] \".+\"])\n    [p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "pam"
+    ],
+    "doc": "<h1><code>++pam</code></h1>\n\n<p>Parse ampersand</p>\n\n<p>Parses ASCII character 38, the ampersand.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  pam  (just '&amp;')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"&amp;\" pam)\n~~~26.\n&gt; `cord`(scan \"&amp;\" pam)\n'&amp;'\n&gt; (pam [[1 1] \"&amp;\"])\n[p=[p=1 q=2] q=[~ [p=~~~26. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (pam [[1 1] \"?&amp;\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "pat"
+    ],
+    "doc": "<h1><code>++pat</code></h1>\n\n<p>Parse \"at\" sign</p>\n\n<p>Parses ASCII character 64, the \"at\" sign.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  pat  (just '@')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"@\" pat)\n~~~4.\n&gt; `cord`(scan \"@\" pat)\n'@'\n&gt; (pat [[1 1] \"@\"])\n[p=[p=1 q=2] q=[~ [p=~~~4. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (pat [[1 1] \"?@\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "pel"
+    ],
+    "doc": "<h1><code>++pel</code></h1>\n\n<p>Parse left parenthesis</p>\n\n<p>Parses ASCII character 40, the left parenthesis.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  pel  (just '(')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"(\" pel)\n~~~28.\n&gt; `cord`(scan \"(\" pel)\n'('\n&gt; (pel [[1 1] \"(\"])\n[p=[p=1 q=2] q=[~ [p=~~~28. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (pel [[1 1] \";(\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "per"
+    ],
+    "doc": "<h1><code>++per</code></h1>\n\n<p>Parse right parenthesis</p>\n\n<p>Parses ASCII character 41, the right parenthesis.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  per  (just ')')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \")\" per)\n~~~29.\n&gt; `cord`(scan \")\" per)\n')'\n&gt; (per [[1 1] \")\"])\n[p=[p=1 q=2] q=[~ [p=~~~29. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (per [[1 1] \" )\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sel"
+    ],
+    "doc": "<h1><code>++sel</code></h1>\n\n<p>Parse left square bracket</p>\n\n<p>Parses ASCII character 91, the left square bracket.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  sel  (just '[')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"[\" sel)\n    ~~~5b.\n    &gt; `cord`(scan \"[\" sel)\n    '['\n    &gt; (sel [[1 1] \"[\"])\n    [p=[p=1 q=2] q=[~ [p=~~~5b. q=[p=[p=1 q=2] q=\"\"]]]]\n    &gt; (sel [[1 1] \"-[\"])\n    [p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sem"
+    ],
+    "doc": "<h1><code>++sem</code></h1>\n\n<p>Parse semicolon</p>\n\n<p>Parses ASCII character 59, the semicolon.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  sem  (just ';')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \";\" sem)\n~~~3b.\n&gt; `cord`(scan \";\" sem)\n';'\n&gt; (sem [[1 1] \";\"])\n[p=[p=1 q=2] q=[~ [p=~~~3b. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (sem [[1 1] \" ;\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "ser"
+    ],
+    "doc": "<h1><code>++ser</code></h1>\n\n<p>Parse right square bracket</p>\n\n<p>Parses ASCII character 93, the right square bracket.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  ser  (just ']')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"]\" ser)\n~~~5d.\n&gt; `cord`(scan \"]\" ser)\n']'\n&gt; (ser [[1 1] \"]\"])\n[p=[p=1 q=2] q=[~ [p=~~~5d. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (ser [[1 1] \"[ ]\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sig"
+    ],
+    "doc": "<h1><code>++sig</code></h1>\n\n<p>Parse tilde</p>\n\n<p>Parses ASCII character 126, the tilde.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  sig  (just '~')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"~\" sig)\n~~~~\n&gt; `cord`(scan \"~\" sig)\n'~'\n&gt; (sig [[1 1] \"~\"])\n[p=[p=1 q=2] q=[~ [p=~~~~ q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (sig [[1 1] \"?~\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "soq"
+    ],
+    "doc": "<h1><code>++soq</code></h1>\n\n<p>Parse single quote</p>\n\n<p>Parses ASCII character 39, soq. Note the extra '' is to escape the first\n<code>soq</code> because soq delimits a <a href=\"\"><code>++cord</code></a>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  soq  (just '\\'')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"'\" soq)\n~~~27.\n&gt; `cord`(scan \"'\" soq)\n'''\n&gt; (soq [[1 1] \"'\"])\n[p=[p=1 q=2] q=[~ [p=~~~27. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (soq [[1 1] \"&gt;'\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tar"
+    ],
+    "doc": "<h1><code>++tar</code></h1>\n\n<p>Parse asterisk</p>\n\n<p>Parses ASCII character 42, the asterisk.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  tar  (just '*')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"*\" tar)\n~~~2a.\n&gt; `cord`(scan \"*\" tar)\n'*'\n&gt; (tar [[1 1] \"*\"])\n[p=[p=1 q=2] q=[~ [p=~~~2a. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (tar [[1 1] \".*\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tec"
+    ],
+    "doc": "<h1><code>++tec</code></h1>\n\n<p>Parse backtick</p>\n\n<p>Parses ASCII character 96, the backtick (also known as the \"grave\naccent\").</p>\n\n<h2>Source</h2>\n\n<pre><code>++  tec  (just '`')                                     ::  backTiCk\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"`\" tec)\n~~~6.\n&gt; `cord`(scan \"`\" tec)\n'`'\n&gt; (tec [[1 1] \"`\"])\n[p=[p=1 q=2] q=[~ [p=~~~6. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (tec [[1 1] \" `\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tis"
+    ],
+    "doc": "<h1><code>++tis</code></h1>\n\n<p>Parse equals sign</p>\n\n<p>Parses ASCII character 61, the equals sign.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  tis  (just '=')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"=\" tis)\n~~~3d.\n&gt; `cord`(scan \"=\" tis)\n'='\n&gt; (tis [[1 1] \"=\"])\n[p=[p=1 q=2] q=[~ [p=~~~3d. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (tis [[1 1] \"|=\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "wut"
+    ],
+    "doc": "<h1><code>++wut</code></h1>\n\n<p>Parses question mark</p>\n\n<p>Parses ASCII character 63, the question mark.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  wut  (just '?')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"?\" wut)\n~~~3f.\n&gt; `cord`(scan \"?\" wut)\n'?'\n&gt; (wut [[1 1] \"?\"])\n[p=[p=1 q=2] q=[~ [p=~~~3f. q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (wut [[1 1] \".?\"])\n[p=[p=1 q=1] q=~]\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "ab"
+    ],
+    "doc": "<h1><code>++ab</code></h1>\n\n<p>Primitive parser engine</p>\n\n<p>A core containing numeric parser primitives.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  ab\n  |%\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ab\n&lt;36.ecc 414.gly 100.xkc 1.ypj %164&gt;\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "bix"
+    ],
+    "doc": "<h1><code>++bix</code></h1>\n\n<p>Parse hex pair</p>\n\n<p>Parsing <code>++rule</code>. Parses a pair of base-16 digits. Used in escapes.</p>\n\n<h2>Accepts</h2>\n\n<p>XX</p>\n\n<h2>Produces</h2>\n\n<p>A an atom. XX</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  bix  (bass 16 (stun [2 2] six))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"07\" bix:ab)\nq=7\n&gt; (scan \"51\" bix:ab)\nq=81\n&gt; (scan \"a3\" bix:ab)\nq=163\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "hif"
+    ],
+    "doc": "<h1><code>++hif</code></h1>\n\n<p>Parse phonetic pair</p>\n\n<p>Parsing <code>++rule</code>. Parses an atom of odor <code>@pE</code>, a phrase of two bytes\nencoded phonetically.</p>\n\n<h2>Accepts</h2>\n\n<p>XX</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  hif  (boss 256 ;~(plug tip tiq (easy ~)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"doznec\" hif:ab)\nq=256\n&gt; (scan \"pittyp\" hif:ab)\nq=48.626\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "huf"
+    ],
+    "doc": "<h1><code>++huf</code></h1>\n\n<p>Parse two phonetic pairs</p>\n\n<p>Parsing <code>++rule</code>. Parses and unscrambles an atom of odor @pF, a phrase\nof two two-byte pairs that are encoded (and scrambled) phonetically.</p>\n\n<h2>Accepts</h2>\n\n<p>XX</p>\n\n<h2>Produces</h2>\n\n<p>An atom. XX</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  huf  %+  cook\n               |=([a/@ b/@] (wred:un ~(zug mu ~(zag mu [a b]))))\n             ;~(plug hif ;~(pfix hep hif))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"pittyp-pittyp\" huf:ab)\n328.203.557\n&gt; (scan \"tasfyn-partyv\" huf:ab)\n65.792\n&gt; `@ux`(scan \"tasfyn-partyv\" huf:ab)\n0x1.0100\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "hyf"
+    ],
+    "doc": "<h1><code>++hyf</code></h1>\n\n<p>Parse 8 phonetic bytes</p>\n\n<p>Parsing <code>++rule</code>. Parses an atom of odor @pG, a phrase of eight of\nphonetic bytes.</p>\n\n<h2>Accepts</h2>\n\n<p>An atom of odor <code>@pG</code></p>\n\n<h2>Produces</h2>\n\n<p>An atom. XX</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  hyf  (bass 0x1.0000.0000 ;~(plug huf ;~(pfix hep huf) (easy ~)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"sondel-forsut-tillyn-nillyt\" hyf:ab)\nq=365.637.097.828.335.095\n&gt; `@u`~sondel-forsut-tillyn-nillyt\n365.637.097.828.335.095\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "pev"
+    ],
+    "doc": "<h1><code>++pev</code></h1>\n\n<p>Parse \\&lt;= 5 base-32</p>\n\n<p>Parsing <code>++rule</code>. Parses up to five base-32 digits without a leading zero.</p>\n\n<h2>Accepts</h2>\n\n<p>Up to five @uv (base 64) digits.</p>\n\n<h2>Produces</h2>\n\n<p>An atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  pev  (bass 32 ;~(plug sev (stun [0 4] siv)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"a\" pev:ab)\nq=10\n&gt; (scan \"290j\" pev:ab)\nq=74.771\n&gt; (scan \"123456\" pev:ab)\n! {1 6}\n! exit\n&gt; (scan \"090j\" pev:ab)\n~ &lt;syntax error at [1 11]&gt;\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "pew"
+    ],
+    "doc": "<h1><code>++pew</code></h1>\n\n<p>Parse \\&lt;= 5 base-64</p>\n\n<p>Parsing <code>++rule</code>. Parses up to five base-64 digits without a leading zero.</p>\n\n<h2>Accepts</h2>\n\n<p>Up to five @uw (base 64) digits.</p>\n\n<h2>Produces</h2>\n\n\n\n<h2>Source</h2>\n\n<pre><code>  ++  pew  (bass 64 ;~(plug sew (stun [0 4] siw)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"Q\" pew:ab)\nq=52\n&gt; (scan \"aQ~9\" pew:ab)\nq=2.838.473\n&gt; `@`0waQ~9\n2.838.473\n&gt; (scan \"123456\" pew:ab)\n! {1 6}\n! exit\n&gt; (scan \"012345\" pew:ab)\n! {1 1}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "piv"
+    ],
+    "doc": "<h1><code>++piv</code></h1>\n\n<p>Parse 5 base-32</p>\n\n<p>Parsing <code>++rule</code>. Parses exactly five base-32 digits.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  piv  (bass 32 (stun [5 5] siv))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"10b3l\" piv:ab)\nq=1.059.957\n&gt; (scan \"1\" piv:ab)\n! {1 2}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "piw"
+    ],
+    "doc": "<h1><code>++piw</code></h1>\n\n<p>Parse 5 base-64</p>\n\n<p>Parsing <code>++rule</code>. Parses exactly five base-64 digits.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  piw  (bass 64 (stun [5 5] siw))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"2C-pZ\" piw:ab)\nq=43.771.517\n&gt; (scan \"2\" piv:ab)\n! {1 2}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "qeb"
+    ],
+    "doc": "<h1><code>++qeb</code></h1>\n\n<p>Parse \\&lt;= 4 binary</p>\n\n<p>Parsing <code>++rule</code>. Parses a binary number of up to 4 digits in length without\na leading zero.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  qeb  (bass 2 ;~(plug seb (stun [0 3] sib)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"1\" qeb:ab)\nq=1\n&gt; (scan \"101\" qeb:ab)\nq=5\n&gt; (scan \"1111\" qeb:ab)\nq=15\n&gt; (scan \"11111\" qeb:ab)\n! {1 5}\n! exit\n&gt; (scan \"01\" qeb:ab)\n! {1 1}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "qex"
+    ],
+    "doc": "<h1><code>++qex</code></h1>\n\n<p>Parse \\&lt;= 4 hex</p>\n\n<p>Parsing <code>++rule</code>. Parses a hexadecimal number of up to 4 digits in length\nwithout a leading zero.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  qex  (bass 16 ;~(plug sex (stun [0 3] hit)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"ca\" qex:ab)\nq=202\n&gt; (scan \"18ac\" qex:ab)\nq=6.316\n&gt; (scan \"18acc\" qex:ab)\n! {1 5}\n! exit\n&gt; (scan \"08ac\" qex:ab)\n! {1 1}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "qib"
+    ],
+    "doc": "<h1><code>++qib</code></h1>\n\n<p>Parse 4 binary</p>\n\n<p>Parsing <code>++rule</code>. Parses exactly four binary digits.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  qib  (bass 2 (stun [4 4] sib))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"0001\" qib:ab)\nq=1\n&gt; (scan \"0100\" qib:ab)\nq=4\n&gt; (scan \"110\" qib:ab)\n! {1 4}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "qix"
+    ],
+    "doc": "<h1><code>++qix</code></h1>\n\n<p>Parse 4 hex</p>\n\n<p>Parsing <code>++rule</code>. Parses exactly four hexadecimal digits.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  qix  (bass 16 (stun [4 4] six))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"0100\" qix:ab)\nq=256\n&gt; (scan \"10ff\" qix:ab)\nq=4.351\n&gt; (scan \"0\" qix:ab)\n! {1 2}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "seb"
+    ],
+    "doc": "<h1><code>++seb</code></h1>\n\n<p>Parse 1</p>\n\n<p>Parsing <code>++rule</code>. Parses the number 1.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  seb  (cold 1 (just '1'))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"1\" seb:ab)\n1\n&gt; (scan \"0\" seb:ab)\n! ~zod/try/~2014.10.23..22.34.21..bfdd/:&lt;[1 1].[1 18]&gt;\n! {1 1}\n&gt; (scan \"2\" seb:ab)\n! ~zod/try/~2014.10.23..22.34.29..d399/:&lt;[1 1].[1 18]&gt;\n! {1 1}\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sed"
+    ],
+    "doc": "<h1><code>++sed</code></h1>\n\n<p>Parse decimal</p>\n\n<p>Parsing <code>++rule</code>. Parses a nonzero decimal digit.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sed  (cook |=(a/@ (sub a '0')) (shim '1' '9'))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"5\" sed:ab)\n5\n&gt; (scan \"0\" sed:ab)\n! {1 1}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sev"
+    ],
+    "doc": "<h1><code>++sev</code></h1>\n\n<p>Parse base-32</p>\n\n<p>Parsing <code>++rule</code>. Parses a nonzero base-32 digit</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sev  ;~(pose sed sov)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"c\" sev:ab)\n12\n~zod/socialnet=&gt; (scan \"0\" sev:ab)\n! {1 1}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sew"
+    ],
+    "doc": "<h1><code>++sew</code></h1>\n\n<p>Parse base-64</p>\n\n<p>Parsing <code>++rule</code>. Parses a nonzero base-64 digit</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sew  ;~(pose sed sow)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"M\" sew:ab)\n48\n&gt; (scan \"0\" sew:ab)\n! {1 1}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sex"
+    ],
+    "doc": "<h1><code>++sex</code></h1>\n\n<p>Parse hex</p>\n\n<p>Parsing <code>++rule</code>. Parses a nonzero hexadecimal digit.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sex  ;~(pose sed sox)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"e\" sex:ab)\n14\n&gt; (scan \"0\" sex:ab)\n! {1 1}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sib"
+    ],
+    "doc": "<h1><code>++sib</code></h1>\n\n<p>Parse binary</p>\n\n<p>Parsing <code>++rule</code>. Parses a binary digit.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sib  (cook |=(a/@ (sub a '0')) (shim '0' '1'))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"1\" sib:ab)\n1\n~zod/socialnet=&gt; (scan \"0\" sib:ab)\n0\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sid"
+    ],
+    "doc": "<h1><code>++sid</code></h1>\n\n<p>Parse decimal</p>\n\n<p>Parsing <code>++rule</code>. Parses a decimal digit.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sid  (cook |=(a/@ (sub a '0')) (shim '0' '9'))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"5\" sid:ab)\n5\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "siv"
+    ],
+    "doc": "<h1><code>++siv</code></h1>\n\n<p>Parse base-32</p>\n\n<p>Parsing <code>++rule</code>. Parses a base-32 digit.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  siv  ;~(pose sid sov)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"c\" siv:ab)\n12\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "siw"
+    ],
+    "doc": "<h1><code>++siw</code></h1>\n\n<p>Parse base-64</p>\n\n<p>Parsing <code>++rule</code>. Parses a base-64 digit.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  siw  ;~(pose sid sow)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"M\" siw:ab)\n48\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "six"
+    ],
+    "doc": "<h1><code>++six</code></h1>\n\n<p>Parse hex</p>\n\n<p>Parsing <code>++rule</code>. Parses a hexadecimal digit.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  six  ;~(pose sid sox)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"e\" six:ab)\n14\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sov"
+    ],
+    "doc": "<h1><code>++sov</code></h1>\n\n<p>Parse base-32</p>\n\n<p>Parsing <code>++rule</code>. Parses a base-32 letter.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sov  (cook |=(a/@ (sub a 87)) (shim 'a' 'v'))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"c\" sov:ab)\n12\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sow"
+    ],
+    "doc": "<h1><code>++sow</code></h1>\n\n<p>Parse base-64</p>\n\n<p>Parsing <code>++rule</code>. Parses a base-64 letter/symbol.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sow  ;~  pose\n             (cook |=(a/@ (sub a 87)) (shim 'a' 'z'))\n             (cook |=(a/@ (sub a 29)) (shim 'A' 'Z'))\n             (cold 62 (just '-'))\n             (cold 63 (just '~'))\n           ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"M\" sow:ab)\n48\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "sox"
+    ],
+    "doc": "<h1><code>++sox</code></h1>\n\n<p>Parse hex letter</p>\n\n<p>Parsing <code>++rule</code>. Parses a hexadecimal letter.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  sox  (cook |=(a/@ (sub a 87)) (shim 'a' 'f'))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"e\" sox:ab)\n14\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "ted"
+    ],
+    "doc": "<h1><code>++ted</code></h1>\n\n<p>Parse \\&lt;= 3 decimal</p>\n\n<p>Parsing <code>++rule</code>. Parses a decimal number of up to 3 digits without a\nleading zero.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  ted  (bass 10 ;~(plug sed (stun [0 2] sid)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"21\" ted:ab)\nq=21\n&gt; (scan \"214\" ted:ab)\nq=214\n&gt; (scan \"2140\" ted:ab)\n{1 4}\n&gt; (scan \"0\" ted:ab)\n! {1 1}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "tip"
+    ],
+    "doc": "<h1><code>++tip</code></h1>\n\n<p>Leading phonetic byte</p>\n\n<p>Parsing <code>++rule</code>. Parses the leading phonetic byte, which represents a\nsyllable.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  tip  (sear |=(a/@ (ins:po a)) til)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"doz\" tip:ab)\n0\n&gt; (scan \"pit\" tip:ab)\n242\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "tiq"
+    ],
+    "doc": "<h1><code>++tiq</code></h1>\n\n<p>Trailing phonetic syllable</p>\n\n<p>Parsing <code>++rule</code>. Parses the trailing phonetic byte, which represents a\nsyllable.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  tiq  (sear |=(a/@ (ind:po a)) til)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"zod\" tiq:ab)\n0\n&gt; (scan \"nec\" tiq:ab)\n1\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "tid"
+    ],
+    "doc": "<h1><code>++tid</code></h1>\n\n<p>Parse 3 decimal digits</p>\n\n<p>Parsing <code>++rule</code>. Parses exactly three decimal digits.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  tid  (bass 10 (stun [3 3] sid))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"013\" tid:ab)\nq=13\n&gt; (scan \"01\" tid:ab)\n! {1 3}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "til"
+    ],
+    "doc": "<h1><code>++til</code></h1>\n\n<p>Parse 3 lowercase</p>\n\n<p>Parsing <code>++rule</code>. Parses exactly three lowercase letters.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  til  (boss 256 (stun [3 3] low))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"mer\" til:ab)\nq=7.497.069\n&gt; `@t`(scan \"mer\" til:ab)\n'mer'\n&gt; (scan \"me\" til:ab)\n! {1 3}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "urs"
+    ],
+    "doc": "<h1><code>++urs</code></h1>\n\n<p>Parse span characters</p>\n\n<p>Parsing rule. Parses characters from an atom of the span odor <code>@ta</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  urs  %+  cook\n             |=(a/tape (rap 3 ^-((list @) a)))\n           (star ;~(pose nud low hep dot sig cab))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ta`(scan \"asa-lom_tak\" urs:ab)\n~.asa-lom_tak \n&gt; `@t`(scan \"asa-lom_tak\" urs:ab)\n'asa-lom_tak'\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "urt"
+    ],
+    "doc": "<h1><code>++urt</code></h1>\n\n<p>Parse non-<code>_</code> span</p>\n\n<p>Parsing rule. Parses all characters of the span odor <code>@ta</code> except\nfor cab, <code>_</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  urt  %+  cook\n             |=(a/tape (rap 3 ^-((list @) a)))\n           (star ;~(pose nud low hep dot sig))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@t`(scan \"asa-lom.t0k\" urt:ab)\n'asa-lom.t0k'\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "voy"
+    ],
+    "doc": "<h1><code>++voy</code></h1>\n\n<p>Parse bas, soq, or bix</p>\n\n<p>Parsing rule. Parses an escaped backslash, single quote, or hex pair\nbyte.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  voy  ;~(pfix bas ;~(pose bas soq bix))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"\\\\0a\" voy:ab)\nq=10\n&gt; (scan \"\\\\'\" voy:ab)\nq=39\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "ag"
+    ],
+    "doc": "<h1><code>++ag</code></h1>\n\n<p>Top-level atom parser engine</p>\n\n<p>A core containing top-level atom parsers.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>++  ag\n  |%\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ag\n&lt;14.vpu 414.mof 100.xkc 1.ypj %164&gt;\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "ape"
+    ],
+    "doc": "<h1><code>++ape</code></h1>\n\n<p>Parse 0 or rule</p>\n\n<p>Parser modifier. Parses 0 or the sample rule <code>fel</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>fel</code> is a <code>rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  ape  |*(fel/rule ;~(pose (cold 0 (just '0')) fel))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"202\" (star (ape:ag (cold 2 (just '2')))))\n~[2 0 2]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "bay"
+    ],
+    "doc": "<h1><code>++bay</code></h1>\n\n<p>Parses binary number</p>\n\n<p>Parsing rule. Parses a binary number without a leading zero.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  bay  (ape (bass 16 ;~(plug qeb:ab (star ;~(pfix dog qib:ab)))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"10.0110\" bay:ag)\nq=38\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "bip"
+    ],
+    "doc": "<h1><code>++bip</code></h1>\n\n<p>Parse IPv6</p>\n\n<p>Parsing rule. Parses a <code>@is</code>, an IPv6 address.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  bip  =+  tod=(ape qex:ab)\n           (bass 0x1.0000 ;~(plug tod (stun [7 7] ;~(pfix dog tod))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"0.0.ea.3e6c.0.0.0.0\" bip:ag)\nq=283.183.420.760.121.105.516.068.864\n&gt; `@is`(scan \"0.0.ea.3e6c.0.0.0.0\" bip:ag)\n.0.0.ea.3e6c.0.0.0.0\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "dem"
+    ],
+    "doc": "<h1><code>++dem</code></h1>\n\n<p>Parse decimal with dots</p>\n\n<p>Parsing rule. Parses a decimal number that includes dot separators.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  dem  (ape (bass 1.000 ;~(plug ted:ab (star ;~(pfix dog tid:ab)))))\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"52\" dem:ag)\nq=52\n&gt; (scan \"13.507\" dem:ag)\nq=13.507\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "dim"
+    ],
+    "doc": "<h1><code>++dim</code></h1>\n\n<p>Parse decimal number</p>\n\n<p>Parsing rule. Parses a decimal number without a leading zero.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  dim  (ape (bass 10 ;~(plug sed:ab (star sid:ab))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"52\" dim:ag)\nq=52\n&gt; (scan \"013507\" dim:ag)\n! {1 2}\n! exit\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "dum"
+    ],
+    "doc": "<h1><code>++dum</code></h1>\n\n<p>Parse decimal with leading <code>0</code></p>\n\n<p>Parsing rule. Parses a decmial number with leading zeroes.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  dum  (bass 10 (plus sid:ab))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"52\" dum:ag)\nq=52\n&gt; (scan \"0000052\" dum:ag)\nq=52\n&gt; (scan \"13507\" dim:ag)\nq=13.507\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "fed"
+    ],
+    "doc": "<h1><code>++fed</code></h1>\n\n<p>Parse phonetic base</p>\n\n<p>Parsing rule. Parses an atom of odor <code>@p</code>, the phonetic base.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  fed  ;~  pose\n             (bass 0x1.0000.0000.0000.0000 (most doh hyf:ab))\n             huf:ab\n             hif:ab\n             tiq:ab\n           ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"zod\" fed:ag)\n0\n&gt; (scan \"nec\" fed:ag)\n1\n&gt; (scan \"sondel\" fed:ag)\n9.636\n&gt; ~tillyn-nillyt\n~tillyn-nillyt\n&gt; (scan \"tillyn-nillyt\" fed:ag)\n3.569.565.175\n&gt; (scan \"tillyn-nillyt-tasfyn-partyv\" fed:ag)\n15.331.165.687.565.582.592\n&gt; (scan \"tillyn-nillyt-tasfyn-partyv--novweb-talrud-talmud-sonfyr\" fed:ag)\n282.810.089.790.159.633.869.501.053.313.363.681.181\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "hex"
+    ],
+    "doc": "<h1><code>++hex</code></h1>\n\n<p>Parse hex</p>\n\n<p>Parsing rule. Parses a hexadecimal number</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  hex  (ape (bass 0x1.0000 ;~(plug qex:ab (star ;~(pfix dog qix:ab)))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"4\" hex:ag)\nq=4\n&gt; (scan \"1a\" hex:ag)\nq=26\n&gt; (scan \"3.ac8d\" hex:ag)\nq=240.781\n&gt; `@ux`(scan \"3.ac8d\" hex:ag)\n0x3.ac8d\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "lip"
+    ],
+    "doc": "<h1><code>++lip</code></h1>\n\n<p>Parse IPv4 address</p>\n\n<p>Parsing rule. Parses an IPv4 address.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  lip  =+  tod=(ape ted:ab)\n           (bass 256 ;~(plug tod (stun [3 3] ;~(pfix dog tod))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"127.0.0.1\" lip:ag)\nq=2.130.706.433\n&gt; `@if`(scan \"127.0.0.1\" lip:ag)\n.127.0.0.1\n&gt; `@if`(scan \"8.8.8.8\" lip:ag)\n.8.8.8.8\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "viz"
+    ],
+    "doc": "<h1><code>++viz</code></h1>\n\n<p>Parse Base-32 with dots</p>\n\n<p>Parsing rule. Parses a Base-32 number with dot separators.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  viz  (ape (bass 0x200.0000 ;~(plug pev:ab (star ;~(pfix dog piv:ab)))))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"e2.ol4pm\" viz:ag)\nq=15.125.353.270\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "vum"
+    ],
+    "doc": "<h1><code>++vum</code></h1>\n\n<p>Parse base-32 string</p>\n\n<p>Parsing rule. Parses a raw base-32 string.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  vum  (bass 32 (plus siv:ab))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"e2ol4pm\" vum:ag)\nq=15.125.353.270\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "wiz"
+    ],
+    "doc": "<h1><code>++wiz</code></h1>\n\n<p>Parse base-64</p>\n\n<p>Parsing rule. Parses a base-64 number.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  wiz  (ape (bass 0x4000.0000 ;~(plug pew:ab (star ;~(pfix dog piw:ab)))))\n  --\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"e2O.l4Xpm\" wiz:ag)\nq=61.764.130.813.526\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mu"
+    ],
+    "doc": "<h1><code>++mu</code></h1>\n\n<p>Core used to scramble 16-bit atoms</p>\n\n<p>A door that contains arms that are used to scramble two atoms, <code>top</code>\nand <code>bot</code>. Used especially in the phonetic base to disguise the\nrelationship between a destroyer and its cruiser.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>bot</code> is an atom.</p>\n\n<p><code>top</code> is an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mu\n  |_  [top/@ bot/@]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ~(. mu 0x20e5 0x5901)\n&lt;3.sjm [[@ux @ux] &lt;414.hhh 100.xkc 1.ypj %164&gt;]&gt;\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "zag"
+    ],
+    "doc": "<h1><code>++zag</code></h1>\n\n<p>Add bottom into top</p>\n\n<p>Produces the cell of <code>top</code> and <code>bot</code> with <code>top</code> scrambled to the result\nof adding <code>bot</code> to <code>top</code> modulo 16. Used to scramble the name of a\ndestroyer.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>bot</code> is an atom.</p>\n\n<p><code>top</code> is an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  zag  [p=(end 4 1 (add top bot)) q=bot]\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `[@ux @ux]`~(zag mu 0x20e0 0x201)\n[0x22e1 0x201]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "zig"
+    ],
+    "doc": "<h1><code>++zig</code></h1>\n\n<p>Subtract bottom from top</p>\n\n<p>The inverse of <code>++zag</code>. Produces the cell of <code>top</code> and <code>bot</code> with\n<code>top</code> unscrambled. The unscrambled <code>top</code> is the sum of the sample <code>top</code>\nand the 16-bit complement of <code>bot</code>. Used to unscramble the name of the\ndestroyer.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>bot</code> is an atom.</p>\n\n<p><code>top</code> is an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  zig  [p=(end 4 1 (add top (sub 0x1.0000 bot))) q=bot]\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `[@ux @ux]`~(zig mu 0x2f46 0x1042)\n[0x1f04 0x1042]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "zug"
+    ],
+    "doc": "<h1><code>++zug</code></h1>\n\n<p>Concatenate into atom</p>\n\n<p>Produces the concatenation of <code>top</code> and <code>bot</code>. Used to assemble a\ndestroyer name.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>bot</code> is an atom.</p>\n\n<p><code>top</code> is an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  zug  (mix (lsh 4 1 top) bot)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@ux`~(zug mu 0x10e1 0xfa)\n0x10e1.00fa\n</code></pre>"
+  },
+  {
+    "keys": [
+      "ne"
+    ],
+    "doc": "<h1><code>++ne</code></h1>\n\n<p>Digit rendering engine</p>\n\n<p>A door containing arms that render digits at bases 10, 16, 32, and\n64.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>tig</code> is an <code>atom</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  ne\n  |_  tig/@\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ~(. ne 20)\n&lt;4.gut [@ud &lt;414.hhh 100.xkc 1.ypj %164&gt;]&gt;\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "d"
+    ],
+    "doc": "<h1><code>++d</code></h1>\n\n<p>Render decimal</p>\n\n<p>Renders a decimal digit as an atom of an ACII byte value.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>tig</code> is an <code>atom</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  d  (add tig '0')\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@t`~(d ne 7)\n'7'\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "x"
+    ],
+    "doc": "<h1><code>++x</code></h1>\n\n<p>Render hex</p>\n\n<p>Renders a hexadecimal digit as an atom of an ASCII byte value.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>tig</code> is an <code>atom</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  x  ?:((gte tig 10) (add tig 87) d)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@t`~(x ne 7)\n'7'\n&gt; `@t`~(x ne 14)\n'e'\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "v"
+    ],
+    "doc": "<h1><code>++v</code></h1>\n\n<p>Render base-32</p>\n\n<p>Renders a base-32 digit as an atom of an ASCII byte value.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  v  ?:((gte tig 10) (add tig 87) d)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@t`~(v ne 7)\n'7'\n&gt; `@t`~(v ne 14)\n'e'\n&gt; `@t`~(v ne 25)\n'p'\n</code></pre>\n\n<hr/>"
+  },
+
+  {
+    "keys": [
+      "co"
+    ],
+    "doc": "<h1><code>++co</code></h1>\n\n<p>Literal rendering engine</p>\n\n<p>A door that contains arms that operate on the sample coin <code>lot</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>lot</code> is a <code>++coin</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  co  !.\n  ~%  %co  ..co  ~\n  =&lt;  |_  lot/coin\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; &lt; 3.nta\n    { lot/{$many {$~ $ta @t} {$~ $ud @ud} $~}\n      &lt;10.cfg 4.jjn {rep/\"\" &lt;402.arm 110.jyx 1.ztu $151&gt;}&gt;\n    }\n    &gt;\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rear"
+    ],
+    "doc": "<h1><code>++rear</code></h1>\n\n<p>Prepend &amp; render as tape</p>\n\n<p>Renders a coin <code>lot</code> as a tape prepended to the sample tape <code>rom</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>rom</code> is a <code>pe</code></p>\n\n<p><code>lot</code> is a <code>++coin</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  rear  |=(rom/tape =&gt;(.(rex rom) rend))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (~(rear co %$ %ux 200) \"--ha\")\n\"0xc8--ha\"\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rent"
+    ],
+    "doc": "<h1><code>++rent</code></h1>\n\n<p>Render as span</p>\n\n<p>Renders a coin <code>lot</code> as a span.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>lot</code> is a <code>++coin</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>      ++  rent  `@ta`(rap 3 rend)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ~(rent co %$ %ux 200)\n~.0xc8\n&gt; `@t`~(rent co %$ %ux 200)\n'0xc8'\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "rend"
+    ],
+    "doc": "<h1><code>++rend</code></h1>\n\n<p>Render as tape</p>\n\n<p>Renders a coin <code>lot</code> as a tape.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>lot</code> is a <code>++coin</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  rend\n    ^-  tape\n    ?:  ?=($blob -.lot)\n      ['~' '0' ((v-co 1) (jam p.lot))]\n    ?:  ?=($many -.lot)\n      :-  '.'\n      |-  ^-  tape\n      ?~   p.lot\n        ['_' '_' rep]\n      ['_' (weld (trip (wack rent(lot i.p.lot))) $(p.lot t.p.lot))]\n    =+  [yed=(end 3 1 p.p.lot) hay=(cut 3 [1 1] p.p.lot)]\n    |-  ^-  tape\n    ?+    yed  (z-co q.p.lot)\n        $c   ['~' '-' (weld (rip 3 (wood (tuft q.p.lot))) rep)]\n        $d\n      ?+    hay  (z-co q.p.lot)\n          $a\n        =+  yod=(yore q.p.lot)\n        =&gt;  ^+(. .(rep ?~(f.t.yod rep ['.' (s-co f.t.yod)])))\n        =&gt;  ^+  .\n            %=    .\n                rep\n              ?:  &amp;(=(~ f.t.yod) =(0 h.t.yod) =(0 m.t.yod) =(0 s.t.yod))\n                rep\n              =&gt;  .(rep ['.' (y-co s.t.yod)])\n              =&gt;  .(rep ['.' (y-co m.t.yod)])\n              ['.' '.' (y-co h.t.yod)]\n            ==\n        =&gt;  .(rep ['.' (a-co d.t.yod)])\n        =&gt;  .(rep ['.' (a-co m.yod)])\n        =&gt;  .(rep ?:(a.yod rep ['-' rep]))\n        ['~' (a-co y.yod)]\n      ::\n          $r\n        =+  yug=(yell q.p.lot)\n        =&gt;  ^+(. .(rep ?~(f.yug rep ['.' (s-co f.yug)])))\n        :-  '~'\n        ?:  &amp;(=(0 d.yug) =(0 m.yug) =(0 h.yug) =(0 s.yug))\n          ['s' '0' rep]\n        =&gt;  ^+(. ?:(=(0 s.yug) . .(rep ['.' 's' (a-co s.yug)])))\n        =&gt;  ^+(. ?:(=(0 m.yug) . .(rep ['.' 'm' (a-co m.yug)])))\n        =&gt;  ^+(. ?:(=(0 h.yug) . .(rep ['.' 'h' (a-co h.yug)])))\n        =&gt;  ^+(. ?:(=(0 d.yug) . .(rep ['.' 'd' (a-co d.yug)])))\n        +.rep\n      ==\n    ::\n        $f\n      ?:  =(&amp; q.p.lot)\n        ['.' 'y' rep]\n      ?:(=(| q.p.lot) ['.' 'n' rep] (z-co q.p.lot))\n    ::\n        $n   ['~' rep]\n        $i\n      ?+  hay  (z-co q.p.lot)\n        $f  ((ro-co [3 10 4] |=(a/@ ~(d ne a))) q.p.lot)\n        $s  ((ro-co [4 16 8] |=(a/@ ~(x ne a))) q.p.lot)\n      ==\n    ::\n        $p\n      =+  dyx=(met 3 q.p.lot)\n      :-  '~'\n      ?:  (lte dyx 1)\n        (weld (trip (tod:po q.p.lot)) rep)\n      ?:  =(2 dyx)\n        ;:  weld\n          (trip (tos:po (end 3 1 q.p.lot)))\n          (trip (tod:po (rsh 3 1 q.p.lot)))\n          rep\n        ==\n      =+  [dyz=(met 5 q.p.lot) fin=| dub=&amp;]\n      |-  ^-  tape\n      ?:  =(0 dyz)\n        rep\n      %=    $\n          fin      &amp;\n          dub      !dub\n          dyz      (dec dyz)\n          q.p.lot  (rsh 5 1 q.p.lot)\n          rep\n        =+  syb=(wren:un (end 5 1 q.p.lot))\n        =+  cog=~(zig mu [(rsh 4 1 syb) (end 4 1 syb)])\n        ;:  weld\n          (trip (tos:po (end 3 1 p.cog)))\n          (trip (tod:po (rsh 3 1 p.cog)))\n          `tape`['-' ~]\n          (trip (tos:po (end 3 1 q.cog)))\n          (trip (tod:po (rsh 3 1 q.cog)))\n          `tape`?.(fin ~ ['-' ?.(dub ~ ['-' ~])])\n          rep\n        ==\n      ==\n    ::\n        $r\n      ?+  hay  (z-co q.p.lot)\n        $d  ['.' '~' (r-co (rlyd q.p.lot))]\n        $h  ['.' '~' '~' (r-co (rlyh q.p.lot))]\n        $q  ['.' '~' '~' '~' (r-co (rlyq q.p.lot))]\n        $s  ['.' (r-co (rlys q.p.lot))]\n      ==\n    ::\n        $u\n      ?:  ?=($c hay)\n        %+  welp  ['0' 'c' (reap (pad:fa q.p.lot) '1')]\n        (c-co (enc:fa q.p.lot))\n      =-  (weld p.gam ?:(=(0 q.p.lot) `tape`['0' ~] q.gam))\n      ^=  gam  ^-  {p/tape q/tape}\n      ?+  hay  [~ ((ox-co [10 3] |=(a/@ ~(d ne a))) q.p.lot)]\n        $b  [['0' 'b' ~] ((ox-co [2 4] |=(a/@ ~(d ne a))) q.p.lot)]\n        $i  [['0' 'i' ~] ((d-co 1) q.p.lot)]\n        $x  [['0' 'x' ~] ((ox-co [16 4] |=(a/@ ~(x ne a))) q.p.lot)]\n        $v  [['0' 'v' ~] ((ox-co [32 5] |=(a/@ ~(x ne a))) q.p.lot)]\n        $w  [['0' 'w' ~] ((ox-co [64 5] |=(a/@ ~(w ne a))) q.p.lot)]\n      ==\n    ::\n        $s\n      %+  weld\n        ?:((syn:si q.p.lot) \"--\" \"-\")\n      $(yed 'u', q.p.lot (abs:si q.p.lot))\n    ::\n        $t\n      ?:  =('a' hay)\n        ?:  =('s' (cut 3 [2 1] p.p.lot))\n          (weld (rip 3 q.p.lot) rep)\n        ['~' '.' (weld (rip 3 q.p.lot) rep)]\n      ['~' '~' (weld (rip 3 (wood q.p.lot)) rep)]\n    ==\n  --\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ~(rend co ~ %ux 200)\n\"0xc8\"\n&gt; ~(rend co %many ~[[%$ ux+200] [%$ p+40]])\n\"._0xc8_~~tem__\"\n&gt; ~(rend co ~ %p 32.819)\n\"~pillyt\"\n&gt; ~(rend co ~ %ux 18)\n\"0x12\"\n&gt; ~(rend co [~ p=[p=%if q=0x7f00.0001]])\n\".127.0.0.1\"\n&gt; `@ux`.127.0.0.1\n2.130.706.433\n&gt; ~(rend co %many ~[[~ %ud 20] [~ %uw 133] [~ %tas 'sam']])\n\"._20_0w25_sam__\"\n&gt; ~(rend co %blob [1 1])\n\"~0ph\"\n&gt; ~0ph\n[1 1]\n&gt; `@uv`(jam [1 1])\n0vph\n</code></pre>"
+  },
+  {
+    "keys": [
+      "alf"
+    ],
+    "doc": "<h1><code>++alf</code></h1>\n\n<p>Alphabetic characters</p>\n\n<p>Parse alphabetic characters, both upper and lowercase.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  alf  ;~(pose low hig)                               ::  alphabetic\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"a\" alf)\n    ~~a\n    &gt; (scan \"A\" alf)\n    ~~~41.\n    &gt; (scan \"AaBbCc\" (star alf))\n    \"AaBbCc\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "aln"
+    ],
+    "doc": "<h1><code>++aln</code></h1>\n\n<p>Alphanumeric characters</p>\n\n<p>Parse alphanumeric characters - both alphabetic characters and numbers.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  aln  ;~(pose low hig nud)                           ::  alphanumeric\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"0\" aln)\n    ~~0\n    &gt; (scan \"alf42\" (star aln))\n    \"alf42\"\n    &gt; (scan \"0123456789abcdef\" (star aln))\n    \"0123456789abcdef\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "alp"
+    ],
+    "doc": "<h1><code>++alp</code></h1>\n\n<p>Alphanumeric and <code>-</code></p>\n\n<p>Parse alphanumeric strings and hep, \"-\".</p>\n\n<h2>Source</h2>\n\n<pre><code>++  alp  ;~(pose low hig nud hep)                       ::  alphanumeric and -\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"7\" alp)\n    ~~7\n    &gt; (scan \"s\" alp)\n    ~~s\n    &gt; (scan \"123abc-\" (star alp))\n    \"123abc-\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "bet"
+    ],
+    "doc": "<h1><code>++bet</code></h1>\n\n<p>Axis syntax <code>-</code>, <code>+</code></p>\n\n<p>Parse the hep and lus axis syntax.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bet  ;~(pose (cold 2 hep) (cold 3 lus))             ::  axis syntax - +\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"-\" bet)\n    2\n    &gt; (scan \"+\" bet)\n    3\n</code></pre>"
+  },
+  {
+    "keys": [
+      "bin"
+    ],
+    "doc": "<h1><code>++bin</code></h1>\n\n<p>Binary to atom</p>\n\n<p>Parse a tape of binary (0s and 1s) and produce its atomic representation.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bin  (bass 2 (most gon but))                        ::  binary to atom\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"0000\" bin)\n    0\n    &gt; (scan \"0001\" bin)\n    1\n    &gt; (scan \"0010\" bin)\n    2\n    &gt; (scan \"100000001111\" bin)\n    2.063\n</code></pre>"
+  },
+  {
+    "keys": [
+      "but"
+    ],
+    "doc": "<h1><code>++but</code></h1>\n\n<p>Binary digit</p>\n\n<p>Parse a single binary digit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  but  (cook |=(a=@ (sub a '0')) (shim '0' '1'))      ::  binary digit\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"0\" but)\n    0\n    &gt; (scan \"1\" but)\n    1\n    &gt; (scan \"01\" but)\n    ! {1 2}\n    ! 'syntax-error'\n    ! exit\n    &gt; (scan \"01\" (star but))\n    ~[0 1]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "cit"
+    ],
+    "doc": "<h1><code>++cit</code></h1>\n\n<p>Octal digit</p>\n\n<p>Parse a single octal digit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  cit  (cook |=(a=@ (sub a '0')) (shim '0' '7'))      ::  octal digit\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"1\" cit)\n    1\n    &gt; (scan \"7\" cit)\n    7\n    &gt; (scan \"8\" cit)\n    ! {1 1}\n    ! 'syntax-error'\n    ! exit\n    &gt; (scan \"60\" (star cit))\n    ~[6 0]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dem"
+    ],
+    "doc": "<h1><code>++dem</code></h1>\n\n<p>Decimal to atom</p>\n\n<p>Parse a decimal number to an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  dem  (bass 10 (most gon dit))                       ::  decimal to atom\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"7\" dem)\n    7\n    &gt; (scan \"42\" dem)\n    42\n    &gt; (scan \"150000000\" dem)\n    150.000.000\n    &gt; (scan \"12456\" dem)\n    12.456\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dit"
+    ],
+    "doc": "<h1><code>++dit</code></h1>\n\n<p>Decimal digit</p>\n\n<p>Parse a single decimal digit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  dit  (cook |=(a=@ (sub a '0')) (shim '0' '9'))      ::  decimal digit\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"7\" dit)\n    7\n    &gt; (scan \"42\" (star dit))\n    ~[4 2]\n    &gt; (scan \"26000\" (star dit))\n    ~[2 6 0 0 0]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dog"
+    ],
+    "doc": "<h1><code>++dog</code></h1>\n\n<p><code>.</code> optional gap</p>\n\n<p>Dot followed by an optional gap, used with numbers.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  dog  ;~(plug dot gay)                               ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; 1.234.\n            703\n1.234.703\n&gt; (scan \"a.        \" ;~(pfix alf dog))\n[~~~. ~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "doh"
+    ],
+    "doc": "<h1><code>++doh</code></h1>\n\n<p><code>@p</code> separator</p>\n\n<p>Phonetic base phrase separator</p>\n\n<h2>Source</h2>\n\n<pre><code>++  doh  ;~(plug ;~(plug hep hep) gay)                  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; ~nopfel-botduc-nilnev-dolfyn--haspub-natlun-lodmur-holtyd\n~nopfel-botduc-nilnev-dolfyn--haspub-natlun-lodmur-holtyd\n/&gt; ~nopfel-botduc-nilnev-dolfyn--\n            haspub-natlun-lodmur-holtyd\n~nopfel-botduc-nilnev-dolfyn--haspub-natlun-lodmur-holtyd\n&gt; (scan \"--\" doh)\n[[~~- ~~-] ~]\n&gt; (scan \"--      \" doh)\n[[~~- ~~-] ~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "dun"
+    ],
+    "doc": "<h1><code>++dun</code></h1>\n\n<p><code>--</code> to <code>~</code></p>\n\n<p>Parse phep, <code>--</code>, to null, <code>~</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  dun  (cold ~ ;~(plug hep hep))                      ::  -- (phep) to ~\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"--\" dun)\n~\n&gt; (dun [[1 1] \"--\"])\n[p=[p=1 q=3] q=[~ u=[p=~ q=[p=[p=1 q=3] q=\"\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "duz"
+    ],
+    "doc": "<h1><code>++duz</code></h1>\n\n<p><code>==</code> to <code>~</code></p>\n\n<p>Parse stet, <code>==</code>, to null <code>~</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  duz  (cold ~ ;~(plug tis tis))                      ::  == (stet) to ~\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"==\" duz)\n~\n&gt; (duz [[1 1] \"== |=...\"])\n[p=[p=1 q=3] q=[~ u=[p=~ q=[p=[p=1 q=3] q=\" |=...\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gah"
+    ],
+    "doc": "<h1><code>++gah</code></h1>\n\n<p>Newline or ' '</p>\n\n<p>Whitespace component, either newline or space.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gah  (mask [`@`10 ' ' ~])                           ::  newline or ace\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>/&gt; ^-  *  ::  show spaces\n            \"\"\"\n               -\n             -\n              -\n            \"\"\"\n[32 32 32 45 10 32 45 10 32 32 45 0]\n/&gt; ^-  *\n            \"\"\"\n\n            \"\"\"\n[32 32 32 10 32 10 32 32 0]\n/&gt; ^-  (list ,@)\n            %-  scan  :_  (star gah)\n            \"\"\"\n\n            \"\"\"\n~[32 32 32 10 32 10 32 32]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gap"
+    ],
+    "doc": "<h1><code>++gap</code></h1>\n\n<p>Plural whitespace</p>\n\n<p>Separates tall runes</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gap  (cold ~ ;~(plug gaq (star ;~(pose vul gah))))  ::  plural whitespace\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gaq"
+    ],
+    "doc": "<h1><code>++gaq</code></h1>\n\n<p>End of line</p>\n\n<p>Two spaces, a newline, or comment.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gaq  ;~  pose                                       ::  end of line\n             (just `@`10)\n             ;~(plug gah ;~(pose gah vul))\n             vul\n         ==\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gaw"
+    ],
+    "doc": "<h1><code>++gaw</code></h1>\n\n<p>Classic whitespace</p>\n\n<p>Terran whitespace.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gaw  (cold ~ (star ;~(pose vul gah)))               ::  classic white\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gay"
+    ],
+    "doc": "<h1><code>++gay</code></h1>\n\n<p>Optional gap</p>\n\n<p>Optional gap.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gay  ;~(pose gap (easy ~))                          ::\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gon"
+    ],
+    "doc": "<h1><code>++gon</code></h1>\n\n<p>Long numbers</p>\n\n<p>Parse long numbers - Numbers which wrap around the shell with the line</p>\n\n<h2>Source</h2>\n\n<p>break     ++  gon  ;~(pose ;~(plug bas gay fas) (easy ~))         ::  long numbers \\ /</p>\n\n<h2>Examples</h2>\n<p>characters bas and fas.</p>\n\n<pre><code>    &gt; (scan \"\\\\/\" gon)\n    [~~~5c. ~ ~~~2f.]\n    &gt; (gon [[1 1] \"\\\\/\"])\n    [p=[p=1 q=3] q=[~ u=[p=[~~~5c. ~ ~~~2f.] q=[p=[p=1 q=3] q=\"\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "gul"
+    ],
+    "doc": "<h1><code>++gul</code></h1>\n\n<p>Axis syntax <code>&lt;</code> or <code>&gt;</code></p>\n\n<p>Parse the axis gal and gar axis syntax.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  gul  ;~(pose (cold 2 gal) (cold 3 gar))             ::  axis syntax &lt; &gt;\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"&lt;\" gul)\n    2\n    &gt; (scan \"&gt;\" gul)\n    3\n</code></pre>"
+  },
+  {
+    "keys": [
+      "hex"
+    ],
+    "doc": "<h1><code>++hex</code></h1>\n\n<p>Hex to atom</p>\n\n<p>Parse any hexadecimal number to an atom.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  hex  (bass 16 (most gon hit))                       ::  hex to atom\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"a\" hex)\n    10\n    &gt; (scan \"A\" hex)\n    10\n    &gt; (scan \"2A\" hex)\n    42\n    &gt; (scan \"1ee7\" hex)\n    7.911\n    &gt; (scan \"1EE7\" hex)\n    7.911\n    &gt; (scan \"1EE7F7\" hex)\n    2.025.463\n    &gt; `@ux`(scan \"1EE7F7\" hex)\n    0x1e.e7f7\n</code></pre>"
+  },
+  {
+    "keys": [
+      "hig"
+    ],
+    "doc": "<h1><code>++hig</code></h1>\n\n<p>Uppercase</p>\n\n<p>Parse a single uppercase letter.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  hig  (shim 'A' 'Z')                                 ::  uppercase\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"G\" hig)\n    ~~~47.\n    &gt; `cord`(scan \"G\" hig)\n    'G'\n    &gt; (scan \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\" (star hig))\n    \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\n    &gt; (hig [[1 1] \"G\"])\n    [p=[p=1 q=2] q=[~ [p=~~~47. q=[p=[p=1 q=2] q=\"\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "hit"
+    ],
+    "doc": "<h1><code>++hit</code></h1>\n\n<p>Hex digits</p>\n\n<p>Parse a single hexadecimal digit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  hit  ;~  pose                                       ::  hex digits\n           dit\n           (cook |=(a=char (sub a 87)) (shim 'a' 'f'))\n           (cook |=(a=char (sub a 55)) (shim 'A' 'F'))\n         ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"a\" hit)\n    10\n    &gt; (scan \"A\" hit)\n    10\n    &gt; (hit [[1 1] \"a\"])\n    [p=[p=1 q=2] q=[~ [p=10 q=[p=[p=1 q=2] q=\"\"]]]]\n    &gt; (scan \"2A\" (star hit))\n    ~[2 10]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "iny"
+    ],
+    "doc": "<h1><code>++iny</code></h1>\n\n<p>Indentation block</p>\n\n<p>Apply <code>++rule</code> to indented block starting at current column number, omitting\nthe leading whitespace.</p>\n\n<h2>Accepts</h2>\n\n<p><code>sef</code> is a <code>++rule</code></p>\n\n<h2>Produces</h2>\n\n<p>A <code>++rule</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  inde  |*  sef/rule                                  :: indentation block\n  |=  nail  ^+  (sef)\n  =+  [har tap]=[p q]:+&lt;\n  =+  lev=(fil 3 (dec q.har) ' ')\n  =+  eol=(just `@t`10)\n  =+  =-  roq=((star ;~(pose prn ;~(sfix eol (jest lev)) -)) har tap)\n      ;~(simu ;~(plug eol eol) eol)\n  ?~  q.roq  roq\n  =+  vex=(sef har(q 1) p.u.q.roq)\n  =+  fur=p.vex(q (add (dec q.har) q.p.vex))\n  ?~  q.vex  vex(p fur)\n  =-  vex(p fur, u.q -)\n  :+  &amp;3.vex\n    &amp;4.vex(q.p (add (dec q.har) q.p.&amp;4.vex))\n  =+  res=|4.vex\n  |-  ?~  res  |4.roq\n  ?.  =(10 -.res)  [-.res $(res +.res)]\n  (welp [`@t`10 (trip lev)] $(res +.res))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"abc\" (iny (star ;~(pose prn (just `@`10)))))\n\"abc\"\n&gt; (scan \"abc\" (star ;~(pose prn (just `@`10))))\n\"abc\"\n&gt; (scan \"  abc\\0ade\" ;~(pfix ace ace (star ;~(pose prn (just `@`10)))))\n\"abc\n    de\"\n&gt; (scan \"  abc\\0ade\" ;~(pfix ace ace (iny (star ;~(pose prn (just `@`10))))))\n! {1 6}\n! exit\n&gt; (scan \"  abc\\0a  de\" ;~(pfix ace ace (iny (star ;~(pose prn (just `@`10))))))\n\"abc\n    de\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "low"
+    ],
+    "doc": "<h1><code>++low</code></h1>\n\n<p>Lowercase</p>\n\n<p>Parse a single lowercase letter.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  low  (shim 'a' 'z')                                 ::  lowercase\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"g\" low)\n    ~~g\n    &gt; `cord`(scan \"g\" low)\n    'g'\n    &gt; (scan \"abcdefghijklmnopqrstuvwxyz\" (star low))\n    \"abcdefghijklmnopqrstuvwxyz\"\n    &gt; (low [[1 1] \"g\"])\n    [p=[p=1 q=2] q=[~ [p=~~g q=[p=[p=1 q=2] q=\"\"]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mes"
+    ],
+    "doc": "<h1><code>++mes</code></h1>\n\n<p>Hexbyte</p>\n\n<p>Parse a hexbyte.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mes  %+  cook                                       ::  hexbyte\n           |=({a/@ b/@} (add (mul 16 a) b))\n         ;~(plug hit hit)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>    &gt; (scan \"2A\" mes)\n    42\n    &gt; (mes [[1 1] \"2A\"])\n    [p=[p=1 q=3] q=[~ u=[p=42 q=[p=[p=1 q=3] q=\"\"]]]]\n    &gt; (scan \"42\" mes)\n    66\n</code></pre>"
+  },
+  {
+    "keys": [
+      "nix"
+    ],
+    "doc": "<h1><code>++nix</code></h1>\n\n<p>Letters and <code>-</code></p>\n\n<p>Parse Letters and <code>-</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  nix  (boss 256 (star ;~(pose aln cab)))             ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"as_me\" nix)\nq=435.626.668.897\n&gt; `@t`(scan \"as_me\" nix)\n'as_me'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "nud"
+    ],
+    "doc": "<h1><code>++nud</code></h1>\n\n<p>Numeric</p>\n\n<p>Parse a numeric character - A number.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  nud  (shim '0' '9')                                 ::  numeric\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"0\" nud)\n~~0\n&gt; (scan \"7\" nud)\n~~7\n&gt; (nud [[1 1] \"1\"])\n[p=[p=1 q=2] q=[~ [p=~~1 q=[p=[p=1 q=2] q=\"\"]]]]\n&gt; (scan \"0123456789\" (star nud))\n\"0123456789\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "prn"
+    ],
+    "doc": "<h1><code>++prn</code></h1>\n\n<p>Printable character</p>\n\n<p>Parse any printable character.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  prn  ;~(less (just `@`127) (shim 32 256))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"h\" prn)\n~~h\n&gt; (scan \"!\" prn)\n~~~21.\n&gt; (scan \"\\01\" prn)\n! {1 1}\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "qit"
+    ],
+    "doc": "<h1><code>++qit</code></h1>\n\n<p>Chars in cord</p>\n\n<p>Parse an individual character to its cord atom representation.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  qit  ;~  pose                                       ::  chars in a cord\n             ;~(less bas soq prn)\n             ;~(pfix bas ;~(pose bas soq mes))          ::  escape chars\n         ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"%\" qit)\n37\n&gt; `@t`(scan \"%\" qit)\n'%'\n&gt; (scan \"0\" qit)\n48\n&gt; (scan \"E\" qit)\n69\n&gt; (scan \"a\" qit)\n97\n&gt; (scan \"\\\\0a\" qit)\n10\n&gt; `@ux`(scan \"\\\\0a\" qit)\n0xa\n&gt; (scan \"cord\" (star qit))\n~[99 111 114 100]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "qit"
+    ],
+    "doc": "<h1><code>++qit</code></h1>\n\n<p>Chars in cord</p>\n\n<p>Parse an individual character to its cord atom representation.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  qit  ;~  pose                                       ::  chars in a cord\n             ;~(less bas soq prn)\n             ;~(pfix bas ;~(pose bas soq mes))          ::  escape chars\n         ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"%\" qit)\n37\n&gt; `@t`(scan \"%\" qit)\n'%'\n&gt; (scan \"0\" qit)\n48\n&gt; (scan \"E\" qit)\n69\n&gt; (scan \"a\" qit)\n97\n&gt; (scan \"\\\\0a\" qit)\n10\n&gt; `@ux`(scan \"\\\\0a\" qit)\n0xa\n&gt; (scan \"cord\" (star qit))\n~[99 111 114 100]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "qut"
+    ],
+    "doc": "<h1><code>++qut</code></h1>\n\n<p>Cord</p>\n\n<p>Parse single-soq cord with <code>\\{gap}/</code> anywhere in the middle, or triple-single\nquote (aka triple-soq) cord, between which must be in an indented block.</p>\n\n<h2>Source</h2>\n\n<pre><code> ++  qut  ;~  pose                                       ::  cord\n             ;~  less  soqs\n               (ifix [soq soq] (boss 256 (more gon qit)))\n             ==\n             %-  inde  %+  ifix\n               :-  ;~  plug  soqs\n                     ;~(pose ;~(plug (plus ace) vul) (just '\\0a'))\n                   ==\n               ;~(plug (just '\\0a') soqs)\n             (boss 256 (star qat))\n         ==\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"'cord'\" qut)\nq=1.685.221.219\n&gt; 'cord'\n'cord'\n&gt; `@ud`'cord'\n1.685.221.219\n/&gt; '''\n            Heredoc isn't prohibited from containing quotes\n            '''\n'Heredoc isn't prohibited from containing quotes'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "soz"
+    ],
+    "doc": "<h1><code>++soz</code></h1>\n\n<p>Delimiting <code>'''</code></p>\n\n<p>Parse a triple-single quote, used for multiline strings.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  soz  ;~(plug soq soq soq)                          ::  delimiting '''\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"'''\" soz)\n[~~~27. ~~~27. ~~~27.]\n&gt; (rash '\"\"\"' soz)\n! {1 1}\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "sym"
+    ],
+    "doc": "<h1><code>++sym</code></h1>\n\n<p>Term</p>\n\n<p>A term: a letter(lowercase), followed by letters, numbers, or <code>-</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  sym\n  %+  cook\n    |=(a=tape (rap 3 ^-((list ,@) a)))\n  ;~(plug low (star ;~(pose nud low hep)))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"sam-2\" sym)\n215.510.507.891\n&gt; `@t`(scan \"sam-2\" sym)\n'sam-2'\n&gt; (scan \"sym\" sym)\n7.174.515\n</code></pre>"
+  },
+  {
+    "keys": [
+      "ven"
+    ],
+    "doc": "<h1><code>++ven</code></h1>\n\n<p><code>+&gt;-</code> axis syntax</p>\n\n<p>Axis syntax parser</p>\n\n<h2>Source</h2>\n\n<pre><code>++  ven  ;~  (comp |=({a/@ b/@} (peg a b)))             ::  +&gt;- axis syntax\n           bet\n           =+  hom=`?`|\n           |=  tub/nail\n           ^-  (like axis)\n           =+  vex=?:(hom (bet tub) (gul tub))\n           ?~  q.vex\n             [p.tub [~ 1 tub]]\n           =+  wag=$(p.tub p.vex, hom !hom, tub q.u.q.vex)\n           ?&gt;  ?=(^ q.wag)\n           [p.wag [~ (peg p.u.q.vex p.u.q.wag) q.u.q.wag]]\n         ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>~zod/arvo=/hoon/hoon&gt; (scan \"-&gt;+\" ven)\n11\n~zod/arvo=/hoon/hoon&gt; `@ub`(scan \"-&gt;+\" ven)\n0b1011\n~zod/arvo=/hoon/hoon&gt; (peg (scan \"-&gt;\" ven) (scan \"+\" ven))\n11\n~zod/arvo=/hoon/hoon&gt; -&gt;+:[[1 2 [3 4]] 5]\n[3 4]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "vit"
+    ],
+    "doc": "<h1><code>++vit</code></h1>\n\n<p>Base64 digit</p>\n\n<p>Parse a standard base64 digit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  vit                                                 ::  base64 digit\n  ;~  pose\n    (cook |=(a/@ (sub a 65)) (shim 'A' 'Z'))\n    (cook |=(a/@ (sub a 71)) (shim 'a' 'z'))\n    (cook |=(a/@ (add a 4)) (shim '0' '9'))\n    (cold 62 (just '-'))\n    (cold 63 (just '+'))\n  ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>~zod/arvo=/hoon/hoon&gt; (scan \"C\" vit)\n2\n~zod/arvo=/hoon/hoon&gt; (scan \"c\" vit)\n28\n~zod/arvo=/hoon/hoon&gt; (scan \"2\" vit)\n54\n~zod/arvo=/hoon/hoon&gt; (scan \"-\" vit)\n62\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "so"
+    ],
+    "doc": "<h1><code>++so</code></h1>\n\n<p>Coin parser engine</p>\n\n<p>Core containing arms that parse <code>++coin</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>++  so\n  |%\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; so\n&lt;10.mkn 414.hhh 100.xkc 1.ypj %164&gt;\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "bisk"
+    ],
+    "doc": "<h1><code>++bisk</code></h1>\n\n<p>Parse odor-atom pair</p>\n\n<p>Parsing rule. Parses an unsigned integer of any permitted base,\nproducing a <code>++dime</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  bisk\n    ;~  pose\n      ;~  pfix  (just '0')\n        ;~  pose\n          (stag %ub ;~(pfix (just 'b') bay:ag))\n          (stag %ui ;~(pfix (just 'i') dim:ag))\n          (stag %ux ;~(pfix (just 'x') hex:ag))\n          (stag %uv ;~(pfix (just 'v') viz:ag))\n          (stag %uw ;~(pfix (just 'w') wiz:ag))\n        ==\n      ==\n      (stag %ud dem:ag)\n    ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"25\" bisk:so)\n[%ud q=25]\n&gt; (scan \"0x12.6401\" bisk:so)\n[%ux q=1.205.249]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "crub"
+    ],
+    "doc": "<h1><code>++crub</code></h1>\n\n<p>Parse <code>@da</code>, <code>@dr</code>, <code>@p</code>, <code>@t</code></p>\n\n<p>Parsing rule. Parses any atom of any of the following odors after a\nleading sig, <code>~</code> into a <code>++dime</code>: <code>@da</code>, <code>@dr</code>, <code>@p</code>,\nand <code>@t</code>, producing a <code>++dime</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  crub\n    ~+\n    ;~  pose\n      %+  cook\n        |=(det/date `dime`[%da (year det)])\n      ;~  plug\n        %+  cook\n          |=({a/@ b/?} [b a])\n        ;~(plug dim:ag ;~(pose (cold | hep) (easy &amp;)))\n        ;~(pfix dot dim:ag)   ::  month\n        ;~(pfix dot dim:ag)   ::  day\n        ;~  pose\n          ;~  pfix\n            ;~(plug dot dot)\n            ;~  plug\n              dum:ag\n              ;~(pfix dot dum:ag)\n              ;~(pfix dot dum:ag)\n              ;~(pose ;~(pfix ;~(plug dot dot) (most dot qix:ab)) (easy ~))\n            ==\n          ==\n          (easy [0 0 0 ~])\n        ==\n      ==\n    ::\n      %+  cook\n        |=  {a/(list {p/?($d $h $m $s) q/@}) b/(list @)}\n        =+  rop=`tarp`[0 0 0 0 b]\n        |-  ^-  dime\n        ?~  a\n          [%dr (yule rop)]\n        ?-  p.i.a\n          $d  $(a t.a, d.rop (add q.i.a d.rop))\n          $h  $(a t.a, h.rop (add q.i.a h.rop))\n          $m  $(a t.a, m.rop (add q.i.a m.rop))\n          $s  $(a t.a, s.rop (add q.i.a s.rop))\n        ==\n      ;~  plug\n        %+  most\n          dot\n        ;~  pose\n          ;~(pfix (just 'd') (stag %d dim:ag))\n          ;~(pfix (just 'h') (stag %h dim:ag))\n          ;~(pfix (just 'm') (stag %m dim:ag))\n          ;~(pfix (just 's') (stag %s dim:ag))\n        ==\n        ;~(pose ;~(pfix ;~(plug dot dot) (most dot qix:ab)) (easy ~))\n      ==\n    ::\n      (stag %p fed:ag)\n      ;~(pfix dot (stag %ta urs:ab))\n      ;~(pfix sig (stag %t urx:ab))\n      ;~(pfix hep (stag %c (cook turf urx:ab)))\n    ==\n  ++  nuck\n    ~/  %nuck  |=  a/nail  %.  a\n    %+  knee  *coin  |.  ~+\n    %-  stew\n    ^.  stet  ^.  limo\n    :~  :-  ['a' 'z']  (cook |=(a/@ta [%$ %tas a]) sym)\n        :-  ['0' '9']  (stag %$ bisk)\n        :-  '-'        (stag %$ tash)\n        :-  '.'        ;~(pfix dot perd)\n        :-  '~'        ;~(pfix sig ;~(pose twid (easy [%$ %n 0])))\n    ==\n  ++  nusk\n    ~+\n    :(sear |=(a/@ta (rush a nuck)) wick urt:ab)\n  ++  perd\n    ~+\n    ;~  pose\n      (stag %$ zust)\n      (stag %many (ifix [cab ;~(plug cab cab)] (more cab nusk)))\n    ==\n  ++  royl\n    ~+\n    =+  ^=  moo\n      |=  a/tape\n      :-  (lent a)\n      (scan a (bass 10 (plus sid:ab)))\n    =+  ^=  voy\n      %+  cook  royl-cell\n      ;~  pose\n        ;~  plug\n          (easy %d)\n          ;~  pose  (cold | hep)  (easy &amp;)  ==\n          ;~  plug  dim:ag\n            ;~  pose\n              ;~(pfix dot (cook moo (plus (shim '0' '9'))))\n              (easy [0 0])\n            ==\n            ;~  pose\n              ;~  pfix\n                (just 'e')\n                ;~(plug ;~(pose (cold | hep) (easy &amp;)) dim:ag)\n              ==\n              (easy [&amp; 0])\n            ==\n          ==\n        ==\n        ;~  plug\n          (easy %i)\n          ;~  sfix\n            ;~  pose  (cold | hep)  (easy &amp;)  ==\n            (jest 'inf')\n          ==\n        ==\n        ;~  plug\n          (easy %n)\n          (cold ~ (jest 'nan'))\n        ==\n      ==\n    ;~  pose\n      (stag %rh (cook rylh ;~(pfix ;~(plug sig sig) voy)))\n      (stag %rq (cook rylq ;~(pfix ;~(plug sig sig sig) voy)))\n      (stag %rd (cook ryld ;~(pfix sig voy)))\n      (stag %rs (cook ryls voy))\n    ==\n  ::\n  ++  royl-cell\n    |=  rn\n    ^-  dn\n    ?.  ?=({$d *} +&lt;)  +&lt;\n    =+  ^=  h\n      (dif:si (new:si f.b i.b) (sun:si d.b))\n    [%d a h (add (mul c.b (pow 10 d.b)) e.b)]\n  ::\n  ++  tash\n    ~+\n    =+  ^=  neg\n        |=  {syn/? mol/dime}  ^-  dime\n        ?&gt;  =('u' (end 3 1 p.mol))\n        [(cat 3 's' (rsh 3 1 p.mol)) (new:si syn q.mol)]\n    ;~  pfix  hep\n      ;~  pose\n        (cook |=(a/dime (neg | a)) bisk)\n        ;~(pfix hep (cook |=(a/dime (neg &amp; a)) bisk))\n      ==\n    ==\n  ::\n  ++  twid\n    ~+\n    ;~  pose\n      (cook |=(a/@ [%blob (cue a)]) ;~(pfix (just '0') vum:ag))\n      (stag %$ crub)\n    ==\n  ::\n  ++  zust\n    ~+\n    ;~  pose\n      (stag %is bip:ag)\n      (stag %if lip:ag)\n      (stag %f ;~(pose (cold &amp; (just 'y')) (cold | (just 'n'))))\n      royl\n    ==\n  --\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"1926.5.12\" crub:so)\n[p=~.da q=170.141.184.449.747.016.871.285.095.307.149.312.000]\n&gt; ([%da @da] (scan \"1926.5.12\" crub:so))\n[%da ~1926.5.12]\n&gt; (scan \"s10\" crub:so)\n[p=~.dr q=184.467.440.737.095.516.160]\n&gt; ([%dr @dr] (scan \"s10\" crub:so))\n[%dr ~s10]\n&gt; (scan \"doznec\" crub:so)\n[%p 256]\n&gt; (scan \".mas\" crub:so)\n[%ta 7.561.581]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "nuck"
+    ],
+    "doc": "<h1><code>++nuck</code></h1>\n\n<p>Top-level coin parser</p>\n\n<p>Parsing rule. Switches on the first character and applies the\ncorresponding <code>++coin</code> parser.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>    ++  nuck\n      ~/  %nuck  |=  a/nail  %.  a\n      %+  knee  *coin  |.  ~+\n      %-  stew\n      ^.  stet  ^.  limo\n      :~  :-  ['a' 'z']  (cook |=(a/@ta [%$ %tas a]) sym)\n          :-  ['0' '9']  (stag %$ bisk)\n          :-  '-'        (stag %$ tash)\n          :-  '.'        ;~(pfix dot perd)\n          :-  '~'        ;~(pfix sig ;~(pose twid (easy [%$ %n 0])))\n      ==\n</code></pre>\n\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"~pillyt\" nuck:so)\n[% p=[p=~.p q=32.819]]\n&gt; (scan \"0x12\" nuck:so)\n[% p=[p=~.ux q=18]]\n&gt; (scan \".127.0.0.1\" nuck:so)\n[% p=[p=~.if q=2.130.706.433]]\n&gt; `@ud`.127.0.0.1\n2.130.706.433\n&gt; (scan \"._20_0w25_sam__\" nuck:so)\n[ %many \n    p\n  ~[[% p=[p=~.ud q=20]] [% p=[p=~.uw q=133]] [% p=[p=~.tas q=7.168.371]]]\n]\n&gt; `@`%sam\n7.168.371\n&gt; (scan \"~0ph\" nuck:so)\n[%blob p=[1 1]]\n&gt; ~0ph\n[1 1]\n&gt; `@uv`(jam [1 1])\n0vph\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "nusk"
+    ],
+    "doc": "<h1><code>++nusk</code></h1>\n\n<p>Parse coin literal with escapes</p>\n\n<p>Parsing rule. Parses a coin literal with escapes. (See also: xx tuple\nformatting).</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  nusk\n    (sear |=(a/@ta (rush (wick a) nuck)) urt:ab)\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; ~.asd_a\n~.asd_a\n&gt; ._1_~~.asd~-a__\n[1 ~.asd_a]\n&gt; (scan \"~~.asd~-a\" nusk:so)\n[% p=[p=~.ta q=418.212.246.369]]\n&gt; ([~ %ta @ta] (scan \"~~.asd~-a\" nusk:so))\n[~ %ta ~.asd_a]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "perd"
+    ],
+    "doc": "<h1><code>++perd</code></h1>\n\n<p>Parsing rule.</p>\n\n<p>Parsing rule. Parses a dime or tuple without their respective standard\nprefixes.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  perd\n    ;~  pose\n      (stag ~ zust)\n      (stag %many (ifix [cab ;~(plug cab cab)] (more cab nusk)))\n    ==\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"y\" perd:so)\n[~ [%f %.y]]\n&gt; (scan \"n\" perd:so)\n[~ [%f %.n]]\n&gt; |\n%.n\n&gt; (scan \"_20_x__\" perd:so)\n[%many [[% p=[p=~.ud q=20]] ~[[% p=[p=~.tas q=120]]]]]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "royl"
+    ],
+    "doc": "<h1><code>++royl</code></h1>\n\n<p>Parse dime float</p>\n\n<p>Parsing rule. Parses a number into a <code>++dime</code> float.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<p>  ++  royl</p>\n<pre><code>~+\n=+  ^=  moo\n  |=  a/tape\n  :-  (lent a)\n  (scan a (bass 10 (plus sid:ab)))\n=+  ^=  voy\n  %+  cook  royl-cell\n  ;~  pose\n    ;~  plug\n      (easy %d)\n      ;~  pose  (cold | hep)  (easy &amp;)  ==\n      ;~  plug  dim:ag\n        ;~  pose\n          ;~(pfix dot (cook moo (plus (shim '0' '9'))))\n          (easy [0 0])\n        ==\n        ;~  pose\n          ;~  pfix\n            (just 'e')\n            ;~(plug ;~(pose (cold | hep) (easy &amp;)) dim:ag)\n          ==\n          (easy [&amp; 0])\n        ==\n      ==\n    ==\n    ;~  plug\n      (easy %i)\n      ;~  sfix\n        ;~  pose  (cold | hep)  (easy &amp;)  ==\n        (jest 'inf')\n      ==\n    ==\n    ;~  plug\n      (easy %n)\n      (cold ~ (jest 'nan'))\n    ==\n  ==\n;~  pose\n  (stag %rh (cook rylh ;~(pfix ;~(plug sig sig) voy)))\n  (stag %rq (cook rylq ;~(pfix ;~(plug sig sig sig) voy)))\n  (stag %rd (cook ryld ;~(pfix sig voy)))\n  (stag %rs (cook ryls voy))\n==\n</code></pre>\n<p>  ::</p>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"~3.14\" royl:so)\n[%rd .~3.13999999999999]\n&gt; .~3.14\n.~3.13999999999999\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "royl-cell"
+    ],
+    "doc": "<h1><code>++royl-cell</code></h1>\n\n<p>XX still not fully functional</p>\n\n<p>Intermediate parsed float convereter</p>\n\n<pre><code>  ++  royl-cell\n    |=  rn\n    ^-  dn\n    ?.  ?=({$d *} +&lt;)  +&lt;\n    =+  ^=  h\n      (dif:si (new:si f.b i.b) (sun:si d.b))\n    [%d a h (add (mul c.b (pow 10 d.b)) e.b)]\n  ::\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "tash"
+    ],
+    "doc": "<h1><code>++tash</code></h1>\n\n<p>Parse signed dime</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p>Parsing rule. Parses a signed number into a <code>++dime</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>  ++  tash\n    ~+\n    =+  ^=  neg\n        |=  {syn/? mol/dime}  ^-  dime\n        ?&gt;  =('u' (end 3 1 p.mol))\n        [(cat 3 's' (rsh 3 1 p.mol)) (new:si syn q.mol)]\n    ;~  pfix  hep\n      ;~  pose\n        (cook |=(a/dime (neg | a)) bisk)\n        ;~(pfix hep (cook |=(a/dime (neg &amp; a)) bisk))\n      ==\n    ==\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"-20\" tash:so)\n[p=~.sd q=39]\n&gt; (,[%sd @sd] (scan \"-20\" tash:so))\n[%sd -20]\n&gt; (,[%sd @sd] (scan \"--20\" tash:so))\n[%sd --20]\n&gt; (,[%sx @sx] (scan \"--0x2e\" tash:so))\n[%sx --0x2e]\n</code></pre>\n\n<hr/>"
+  },
+  {
+    "keys": [
+      "twid"
+    ],
+    "doc": "<h1><code>++twid</code></h1>\n\n<p>Parse coins without <code>~</code> prefix</p>\n\n<p>Parsing rule. Parses coins after a leading sig, <code>~</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<h2>Source</h2>\n\n<pre><code>  ++  twid\n    ;~  pose\n      (cook |=(a/@ [%blob (cue a)]) ;~(pfix (just '0') vum:ag))\n      (stag ~ crub)\n    ==\n  ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"zod\" twid:so)\n[~ [%p 0]]\n&gt; (scan \".sam\" twid:so)\n[~ [%ta 7.168.371]]\n&gt; `@ud`~.sam\n7.168.371\n&gt; `@t`~.sam\n'sam'\n&gt; (scan \"0ph\" twid:so)\n[%blob [1 1]]\n</code></pre>\n\n<hr/>"
+  },
+
+  {
+    "keys": [
+      "scot"
+    ],
+    "doc": "<h1><code>++scot</code></h1>\n\n<p>Render dime as cord</p>\n\n<p>Renders a dime <code>mol</code> as a cord.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>mol</code> is a <code>++dime</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  scot  |=(mol/dime ~(rent co %$ mol))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scot %p ~pillyt)\n~.~pillyt\n&gt; `@t`(scot %p ~pillyt)\n'~pillyt'\n&gt; (scot %ux 0x12)\n~.0x12\n&gt; `@t`(scot %ux 0x12)\n'0x12'\n&gt; (scot %if .127.0.0.1)\n~..127.0.0.1\n&gt; `@t`(scot %if .127.0.0.1)\n'.127.0.0.1'\n&gt; (scot %ta ~.asd_a)\n~.~.asd_a\n&gt; `@t`(scot %ta ~.asd_a)\n'~.asd_a'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "scow"
+    ],
+    "doc": "<h1><code>++scow</code></h1>\n\n<p>Render dime as tape</p>\n\n<p>Renders <code>mol</code> as a tape.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>mol</code> is a <code>++dime</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  scow  |=(mol/dime ~(rend co %$ mol))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scow %p ~pillyt)\n\"~pillyt\"\n&gt; (scow %ux 0x12)\n\"0x12\"\n&gt; (scow %if .127.0.0.1)\n\".127.0.0.1\"\n&gt; (scow %ta ~.asd_a)\n\"~.asd_a\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "slat"
+    ],
+    "doc": "<h1><code>++slat</code></h1>\n\n<p>Curried slaw</p>\n\n<p>Produces a <code>gate</code> that parses a <code>term</code> <code>txt</code> to an atom of the\nodor specified by <code>mod</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>mod</code> is a term, an atom of odor <code>@tas</code>.</p>\n\n<p><code>txt</code> is a span, an atom of odor <code>@ta</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  slat  |=(mod/@tas |=(txt/@ta (slaw mod txt)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `(unit @p)`((slat %p) '~pillyt')\n[~ ~pillyt]\n&gt; `(unit @ux)`((slat %ux) '0x12')\n[~ 0x12]\n&gt; `(unit @if)`((slat %if) '.127.0.0.1')\n[~ .127.0.0.1]\n&gt; `(unit @ta)`((slat %ta) '~.asd_a')\n[~ ~.asd_a\n</code></pre>"
+  },
+  {
+    "keys": [
+      "slav"
+    ],
+    "doc": "<h1><code>++slav</code></h1>\n\n<p>Demand: parse span with input odor</p>\n\n<p>Parses a span <code>txt</code> to an atom of the odor specificed by <code>mod</code>. Crashes\nif it failes to parse.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>mod</code> is a term, an atom of odor <code>@tas</code>.</p>\n\n<p><code>txt</code> is a span, an atom of odor <code>@ta</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  slav  |=([mod/@tas txt/@ta] (need (slaw mod txt)))\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `@p`(slav %p '~pillyt')\n~pillyt\n&gt; `@p`(slav %p '~pillam')\n! exit\n&gt; `@ux`(slav %ux '0x12')\n0x12\n&gt; `@ux`(slav %ux '0b10')\n! exit\n&gt; `@if`(slav %if '.127.0.0.1')\n.127.0.0.1\n&gt; `@if`(slav %if '.fe80.0.0.202')\n! exit\n&gt; `@ta`(slav %ta '~.asd_a')\n~.asd_a\n&gt; `@ta`(slav %ta '~~asd-a')\n! exit\n</code></pre>"
+  },
+  {
+    "keys": [
+      "slaw"
+    ],
+    "doc": "<h1><code>++slaw</code></h1>\n\n<p>Parse span to input odor</p>\n\n<p>Parses a span <code>txt</code> to an atom of the odor specified by <code>mod</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>mod</code> is a term, an atom of odor <code>@tas</code>.</p>\n\n<p><code>txt</code> is a span, an atom of odor <code>@ta</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  slaw\n  ~/  %slaw\n  |=  {mod/@tas txt/@ta}\n  ^-  (unit @)\n  =+  con=(slay txt)\n  ?.(&amp;(?=({$~ $$ @ @} con) =(p.p.u.con mod)) ~ [~ q.p.u.con])\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `(unit @p)`(slaw %p '~pillyt')\n[~ ~pillyt]\n&gt; `(unit @p)`(slaw %p '~pillam')\n~\n&gt; `(unit @ux)`(slaw %ux '0x12')\n[~ 0x12]\n&gt; `(unit @ux)`(slaw %ux '0b10')\n~\n&gt; `(unit @if)`(slaw %if '.127.0.0.1')\n[~ .127.0.0.1]\n&gt; `(unit @if)`(slaw %if '.fe80.0.0.202')\n~\n&gt; `(unit @ta)`(slaw %ta '~.asd_a')\n[~ ~.asd_a]\n&gt; `(unit @ta)`(slaw %ta '~~asd-a')\n~\n</code></pre>"
+  },
+  {
+    "keys": [
+      "slay"
+    ],
+    "doc": "<h1><code>++slay</code></h1>\n\n<p>Parse span to coin</p>\n\n<p>Parses a span <code>txt</code> to the unit of a <code>++coin</code>.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>txt</code> is a <code>@ta</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  slay\n      |=  txt/@ta  ^-  (unit coin)\n      =+  ^=  vex\n          ?:  (gth 0x7fff.ffff txt)                         ::  XX  petty cache\n            ~+  ((full nuck:so) [[1 1] (trip txt)])\n          ((full nuck:so) [[1 1] (trip txt)])\n      ?~  q.vex\n        ~\n      [~ p.u.q.vex]\n    ::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (slay '~pillyt')\n[~ [% p=[p=~.p q=32.819]]]\n&gt; (slay '0x12')\n[~ [% p=[p=~.ux q=18]]]\n&gt; (slay '.127.0.0.1')\n[~ [% p=[p=~.if q=2.130.706.433]]]\n&gt; `@ud`.127.0.0.1\n2.130.706.433\n&gt; (slay '._20_0w25_sam__')\n[ ~\n  [ %many\n    p=~[[% p=[p=~.ud q=20]] [% p=[p=~.uw q=133]] [% p=[p=~.tas q=7.168.371]]]\n  ]\n]\n&gt; `@`%sam\n7.168.371\n&gt; (slay '~0ph')\n[~ [%blob p=[1 1]]]\n&gt; 0ph\n~ &lt;syntax error at [1 2]&gt;\n&gt; ~0ph\n[1 1]\n&gt; `@uv`(jam [1 1])\n0vph\n</code></pre>"
+  },
+  {
+    "keys": [
+      "smyt"
+    ],
+    "doc": "<h1><code>++smyt</code></h1>\n\n<p>Render path as tank</p>\n\n<p>Renders the path <code>bon</code> as a <code>tank</code>, which is used for\npretty-printing.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>bon</code> is a <code>++path</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  smyt                                                ::  pretty print path\n  |=  bon/path  ^-  tank\n  :+  %rose  [['/' ~] ['/' ~] ~]\n  (turn bon |=(a/@ [%leaf (trip a)]))\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (smyt %)\n[ %rose\n  p=[p=\"/\" q=\"/\" r=\"/\"]\n    q\n  ~[ [%leaf p=\"~zod\"]\n     [%leaf p=\"try\"] \n     [%leaf p=\"~2014.10.28..18.36.58..a280\"]\n   ]\n]\n&gt; (smyt /as/les/top)\n[ %rose\n  p=[p=\"/\" q=\"/\" r=\"/\"]\n  q=~[[%leaf p=\"as\"] [%leaf p=\"les\"] [%leaf p=\"top\"]]\n]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "spat"
+    ],
+    "doc": "<h1><code>++spat</code></h1>\n\n<p>Render path as cord</p>\n\n<p>Renders a path <code>pax</code> as cord.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>pax</code> is a <code>path</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  spat  |=(pax/path (crip (spud pax)))               ::  path to cord\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (spat %)\n'~zod/try/~2014.10.28..18.40.20..4287'\n&gt; (spat %/bin)\n'~zod/try/~2014.10.28..18.41.12..3bcd/bin'\n&gt; (spat /as/les/top)\n'/as/les/top'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "spud"
+    ],
+    "doc": "<h1><code>++spud</code></h1>\n\n<p>Render path as tape</p>\n\n<p>Renders a path <code>pax</code> as tape.</p>\n\n<h2>Accepts</h2>\n\n<h2>Produces</h2>\n\n<p><code>pax</code> is a <code>path</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  spud  |=(pax/path ~(ram re (smyt pax)))             ::  path to tape\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (spud %)\n\"~zod/try/~2014.10.28..18.40.46..e951\"\n&gt; (spud %/bin)\n\"~zod/try/~2014.10.28..18.41.05..16f2/bin\"\n&gt; (spud /as/les/top)\n\"/as/les/top\"\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "mack"
+    ],
+    "doc": "<h1><code>++mack</code></h1>\n\n<p>Nock subject to unit</p>\n\n<p>Accepts a nock subject-formula cell and wraps it into a <code>++unit</code>.\n<code>fol</code> is pure nock, meaning that nock <code>11</code> operations result in a block,\nproducing a <code>~</code>.</p>\n\n<h2>Accepts</h2>\n\n<p><code>sub</code> is a subject noun.</p>\n\n<p><code>fol</code> is a formula noun, which is generally a <code>++nock</code>.</p>\n\n<h2>Produces</h2>\n\n<p>The <code>++unit</code> of a noun.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mack\n  |=  {sub/* fol/*}\n  ^-  (unit)\n  =+  ton=(mink [sub fol] |=({* *} ~))\n  ?.(?=({$0 *} ton) ~ [~ p.ton])\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mack [[1 2 3] [0 1]])\n[~ [1 2 3]]\n&gt; (mack [41 4 0 1])\n[~ 42]\n&gt; (mack [4 0 4])\n~\n&gt; (mack [[[0 2] [1 3]] 4 4 4 4 0 5])\n[~ 6]\n&gt; ;;((unit @tas) (mack [[1 %yes %no] 6 [0 2] [0 6] 0 7]))\n[~ %no]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mink"
+    ],
+    "doc": "<h1><code>++mink</code></h1>\n\n<p>Mock interpreter</p>\n\n<p>Bottom-level mock (virtual nock) interpreter. Produces a\n<code>++tone</code>, a nock computation result. If nock 11 is invoked, <code>sky</code>\ncomputes on the subject and produces a <code>++unit</code> result. An empty\nresult becomes a <code>%1</code> <code>++tone</code>, indicating a block.</p>\n\n<h2>Accepts</h2>\n\n<p><code>sub</code> is the subject as a noun.</p>\n\n<p><code>fol</code> is the formula as a noun.</p>\n\n<p><code>sky</code> is an <code>%iron</code> gate invoked with nock operator 11.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++tone</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mink\n  ~/  %mink\n  |=  {{sub/* fol/*} gul/$-({* *} (unit (unit)))}\n  =+  tax=*(list {@ta *})\n  |-  ^-  tone\n  ?@  fol\n    [%2 tax]\n  ?:  ?=(^ -.fol)\n    =+  hed=$(fol -.fol)\n    ?:  ?=($2 -.hed)\n      hed\n    =+  tal=$(fol +.fol)\n    ?-  -.tal\n      $0  ?-(-.hed $0 [%0 p.hed p.tal], $1 hed)\n      $1  ?-(-.hed $0 tal, $1 [%1 (weld p.hed p.tal)])\n      $2  tal\n    ==\n  ?+    fol\n    [%2 tax]\n  ::\n      {$0 b/@}\n    ?:  =(0 b.fol)  [%2 tax]\n    ?:  =(1 b.fol)  [%0 sub]\n    ?:  ?=(@ sub)   [%2 tax]\n    =+  [now=(cap b.fol) lat=(mas b.fol)]\n    $(b.fol lat, sub ?:(=(2 now) -.sub +.sub))\n  ::\n      {$1 b/*}\n    [%0 b.fol]\n  ::\n      {$2 b/{^ *}}\n    =+  ben=$(fol b.fol)\n    ?.  ?=($0 -.ben)  ben\n    ?&gt;(?=(^ p.ben) $(sub -.p.ben, fol +.p.ben))\n    ::?&gt;(?=(^ p.ben) $([sub fol] p.ben)\n  ::\n      {$3 b/*}\n    =+  ben=$(fol b.fol)\n    ?.  ?=($0 -.ben)  ben\n    [%0 .?(p.ben)]\n  ::\n      {$4 b/*}\n    =+  ben=$(fol b.fol)\n    ?.  ?=($0 -.ben)  ben\n    ?.  ?=(@ p.ben)  [%2 tax]\n    [%0 .+(p.ben)]\n  ::\n      {$5 b/*}\n    =+  ben=$(fol b.fol)\n    ?.  ?=($0 -.ben)  ben\n    ?.  ?=(^ p.ben)  [%2 tax]\n    [%0 =(-.p.ben +.p.ben)]\n  ::\n      {$6 b/* c/* d/*}\n    $(fol =&gt;(fol [2 [0 1] 2 [1 c d] [1 0] 2 [1 2 3] [1 0] 4 4 b]))\n  ::\n      {$7 b/* c/*}       $(fol =&gt;(fol [2 b 1 c]))\n      {$8 b/* c/*}       $(fol =&gt;(fol [7 [[0 1] b] c]))\n      {$9 b/* c/*}       $(fol =&gt;(fol [7 c 0 b]))\n      {$10 @ c/*}        $(fol c.fol)\n      {$10 {b/* c/*} d/*}\n    =+  ben=$(fol c.fol)\n    ?.  ?=($0 -.ben)  ben\n    ?:  ?=(?($hunk $hand $lose $mean $spot) b.fol)\n      $(fol d.fol, tax [[b.fol p.ben] tax])\n    $(fol d.fol)\n  ::\n      {$11 b/* c/*}\n    =+  ref=$(fol b.fol)\n    =+  ben=$(fol c.fol)\n    ?.  ?=($0 -.ref)  ref\n    ?.  ?=($0 -.ben)  ben\n    =+  val=(gul p.ref p.ben)\n    ?~(val [%1 p.ben ~] ?~(u.val [%2 [[%hunk (mush p.ben)] tax]] [%0 u.u.val]))\n  ==\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mink [20 [4 0 1]] $~)\n[%0 p=21]\n&gt; (mink [[90 5 3] [0 3]] $~)\n[%0 p=[5 3]]\n&gt; (mink 20^[4 0 1] $~)\n[%0 p=21]\n&gt; (mink [90 5 3]^[0 3] $~)\n[%0 p=[5 3]]\n&gt; (mink [0]^[11 1 20] $~)\n[%1 p=~[20]]\n&gt; (mink [0]^[11 1 20] |=(a=* `[40 a]))\n[%0 p=[40 20]]\n&gt; (mink [5]^[0 2] $~)\n[%2 p=~]\n&gt; (mink [5]^[10 yelp/[0 1] 0 0] $~)\n[%2 p=~[[~.yelp 5]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mock"
+    ],
+    "doc": "<h1><code>++mock</code></h1>\n\n<p>Compute formula on subject with hint</p>\n\n<p>Produces a <code>++toon</code>, which is either a sucessful, blocked, or\ncrashed result. If nock 11 is invoked, <code>sky</code> computes on the subject and\nproduces a <code>++unit</code> result. An empty result becomes a <code>%1</code> <code>++tune</code>,\nindicating a block.</p>\n\n<h2>Accepts</h2>\n\n<p><code>sub</code> is the subject as a noun.</p>\n\n<p><code>fol</code> is the formula as a noun.</p>\n\n<p><code>sky</code> is an %iron gate invoked with nock operator 11.</p>\n\n<h2>Produces</h2>\n\n<p>The <code>++unit</code> of a noun.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mock\n  |=  {{sub/* fol/*} gul/$-({* *} (unit (unit)))}\n  (mook (mink [sub fol] gul))\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mock [5 4 0 1] ,~)\n[%0 p=6]\n&gt; (mock [~ 11 1 0] |=(* `999))\n[%0 p=999]\n&gt; (mock [~ 0 1.337] ,~)\n[%2 p=~]\n&gt; (mock [~ 11 1 1.337] ,~)\n[%1 p=~[1.337]]\n&gt; (mock [[[4 4 4 4 0 3] 10] 11 9 2 0 1] |=(* `[+&lt;]))\n[%0 p=14]\n&gt; (mock [[[4 4 4 4 0 3] 10] 11 9 2 0 1] |=(* `[&lt;+&lt;&gt;]))\n[%0 p=[49 52 0]]\n&gt; ;;(tape +:(mock [[[4 4 4 4 0 3] 10] 11 9 2 0 1] |=(* `[&lt;+&lt;&gt;])))\n\"14\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mong"
+    ],
+    "doc": "<h1><code>++mong</code></h1>\n\n<p>Slam gate with sample</p>\n\n<p>Produces a <code>++toon</code> computation result from slamming <code>gat</code> with\n<code>sam</code>, using <code>sky</code> to compute or block on nock 11 when applicable.</p>\n\n<h2>Accepts</h2>\n\n<p><code>gat</code> is a noun that is generally a <code>gate</code>.</p>\n\n<p><code>sam</code> is a <code>sample</code> noun.</p>\n\n<p><code>sky</code> is an %iron gate invoked with nock operator 11.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++toon</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mong\n  |=  {{gat/* sam/*} gul/$-({* *} (unit (unit)))}\n  ^-  toon\n  ?.  &amp;(?=(^ gat) ?=(^ +.gat))\n    [%2 ~]\n  (mock [[-.gat [sam +&gt;.gat]] -.gat] gul)\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mong [|=(@ 20) ~] ,~)\n[%0 p=20]\n&gt; (mong [|=(@ !!) ~] ,~)\n[%2 p=~]\n&gt; (mong [|=(a/@ (add 20 a)) ~] ,~)\n[%0 p=20]\n&gt; (mong [|=(a/[@ @] (add 20 -.a)) ~] ,~)\n[%2 p=~]\n&gt; (mong [|=(a/[@ @] (add 20 -.a)) [4 6]] ,~)\n[%0 p=24]\n&gt; (mong [|=(a/@ .^(a)) ~] ,~)\n[%1 p=~[0]]\n&gt; (mong [|=(a/@ .^(a)) ~] ,[~ %42])\n[%0 p=42]\n&gt; (mong [|=(a/@ .^(a)) ~] |=(a/* [~ a 6]))\n[%0 p=[0 6]]\n&gt; (mong [|=(a/@ .^(a)) 8] |=(a/* [~ a 6]))\n[%0 p=[8 6]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mook"
+    ],
+    "doc": "<h1><code>++mook</code></h1>\n\n<p>Intelligently render crash annotation</p>\n\n<p>Converts a <code>%2</code> <code>++tone</code> nock stack trace to a list of <code>++tank</code>.\nEach may be a tank, cord, <code>++spot</code>, or trapped tank.</p>\n\n<h2>Accepts</h2>\n\n<p><code>ton</code> is a <code>++tone</code>.</p>\n\n<h2>Produces</h2>\n\n<p>A <code>++toon</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mook\n  |=  ton/tone\n  ^-  toon\n  ?.  ?=({$2 *} ton)  ton\n  :-  %2\n  :: =.  p.ton  (moop p.ton)\n  =+  yel=(lent p.ton)\n  =.  p.ton\n    ?.  (gth yel 256)  p.ton\n    %+  weld\n      (scag 128 p.ton)\n    ^-  (list {@ta *})\n    :_  (slag (sub yel 128) p.ton)\n    :-  %lose\n    %+  rap  3\n    \"[skipped {(scow %ud (sub yel 256))} frames]\"\n  |-  ^-  (list tank)\n  ?~  p.ton  ~\n  =+  rep=$(p.ton t.p.ton)\n  ?+    -.i.p.ton  rep\n      $hunk  [(tank +.i.p.ton) rep]\n      $lose  [[%leaf (rip 3 (@ +.i.p.ton))] rep]\n      $hand  [[%leaf (scow %p (mug +.i.p.ton))] rep]\n      $mean  :_  rep\n             ?@  +.i.p.ton  [%leaf (rip 3 (@ +.i.p.ton))]\n             =+  mac=(mack +.i.p.ton +&lt;.i.p.ton)\n             ?~(mac [%leaf \"####\"] (tank u.mac))</h2>\n<pre><code>      $spot  :_  rep\n             =+  sot=(spot +.i.p.ton)\n             :+  %rose  [\":\" ~ ~]\n             :~  (smyt p.sot)\n                 =&gt;  [ud=|=(a/@u (scow %ud a)) q.sot]\n                 leaf+\"&lt;[{(ud p.p)} {(ud q.p)}].[{(ud p.q)} {(ud q.q)}]&gt;\"\n  ==         ==\n::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mook [%0 5 4 5 1])\n[%0 p=[5 4 5 1]]\n&gt; (mook [%2 ~[[%hunk %rose [\"&lt;\" \",\" \"&gt;\"] ~[[%leaf \"err\"]]]]])\n[%2 p=~[[%rose p=[p=\"&lt;\" q=\",\" r=\"&gt;\"] q=[i=[%leaf p=\"err\"] t=~]]]]\n&gt; (mook [%2 ~[[%malformed %elem] [%lose 'do print']]])\n[%2 p=~[[%leaf p=\"do print\"]]]\n&gt; (mook [%2 ~[[%mean |.(&gt;(add 5 6)&lt;)]]])\n[%2 p=~[[%leaf p=\"11\"]]]\n&gt; (mook [%2 ~[[%spot /b/repl [1 1]^[1 2]] [%mean |.(!!)]]])\n[%2 p=~[[%leaf p=\"/b/repl/:&lt;[1 1].[1 2]&gt;\"] [%leaf p=\"\n</code></pre>"
+  },
+  {
+    "keys": [
+      "mule"
+    ],
+    "doc": "<h1><code>++mule</code></h1>\n\n<p>Typed virtual</p>\n\n<p>Kicks a <code>++trap</code>, producing its results or any errors that occur along\nthe way. Used to lazily compute stack traces.</p>\n\n<h2>Accepts</h2>\n\n<p><code>taq</code> is a <code>++trap</code>, generally producing a list of <code>++tank</code>s.</p>\n\n<h2>Produces</h2>\n\n<p>XX</p>\n\n<h2>Source</h2>\n\n<pre><code>++  mule                                                ::  typed virtual\n  ~/  %mule\n  |*  taq/_|.(**)\n  =+  mud=(mute taq)\n  ?-  -.mud\n    $&amp;  [%&amp; p=$:taq]                                    ::  XX transition\n    $|  [%| p=p.mud]\n  ==\n::\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mule |.(leaf/\"hello\"))\n[%.y p=[%leaf \"hello\"]]\n&gt; (mule |.(!!))\n[%.n p=~]\n&gt; (mule |.(.^(a//=pals/1)))\n[ %.n\n    p\n  ~[\n    [ %rose\n      p=[p=\"/\" q=\"/\" r=\"/\"]\n        q\n      [ i=[%leaf p=\"a\"] \n        t=[i=[%leaf p=\"~zod\"] t=[i=[%leaf p=\"pals\"] t=[i=[%leaf p=\"1\"] t=~]]]\n      ]\n    ]\n  ]\n]\n</code></pre>"
+  },
+
+  {
+    "keys": [
+      "abel"
+    ],
+    "doc": "<h1><code>++abel</code></h1>\n\n<p>Biblical names in hoon are primarily aliases for the compiler.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  abel  typo                                          ::  original sin: type\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *abel\n%void\n</code></pre>"
+  },
+  {
+    "keys": [
+      "aura"
+    ],
+    "doc": "<h1><code>++aura</code></h1>\n\n<p>'type' of atom</p>\n\n<p>By convention, a short name for a category of atom. <code>++aura</code> is\ncircularly defined, with <a href=\"\"><code>@ta</code></a> being the <code>++aura</code> of the ASCII subset\ncommonly used in urbit.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  aura  ,@ta                                          ::  atom format\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>See also: <a href=\"\"><code>++base</code></a>, <a href=\"\">aura reference</a></p>\n\n<pre><code>&gt; `aura`%ux\n~.ux\n</code></pre>"
+  },
+  {
+    "keys": [
+      "axis"
+    ],
+    "doc": "<h1><code>++axis</code></h1>\n\n<p>Nock axis</p>\n\n<p>A Nock axis inside a <a href=\"\">noun</a>. After the leading 1, in binary, a <code>1</code> signfies\nright and <code>0</code> left.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  axis  ,@                                            ::  tree address\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *axis\n0\n\n&gt; :: 0 is not actually a valid axis\n&gt; [[4 5] 6 7]\n[[4 5] 6 7]\n&gt; `axis`0b110\n6\n</code></pre>"
+  },
+  {
+    "keys": [
+      "base"
+    ],
+    "doc": "<h1><code>++base</code></h1>\n\n<p>Base type</p>\n\n<p>A base type that <a href=\"\">noun</a>s are built from. A <code>++base</code> is either a noun, cell, boolean or\nnull labelled with an <a href=\"\">odor</a>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  base  ?([%atom p=odor] %noun %cell %bean %null)     ::  axils, @ * ^ ? ~\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *base\n%null\n\n&gt; (ream '=|(^ !!)')\n[%tsbr p=[%axil p=%cell] q=[%zpzp ~]]\n&gt; :: p.p is a ++base\n&gt; (ream '=|(@t !!)')\n[%tsbr p=[%axil p=[%atom p=~.t]] q=[%zpzp ~]]\n&gt; (ream '=|(? !!)')\n[%tsbr p=[%axil p=%bean] q=[%zpzp ~]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "bean"
+    ],
+    "doc": "<h1><code>++bean</code></h1>\n\n<p>Boolean</p>\n\n<p><code>0</code>, <code>&amp;</code>, or <code>%.y</code> are true, and <code>1</code>, <code>|</code>, and <code>%.n</code> are false.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  bean  ,?                                            ::  0=&amp;=yes, 1=|=no\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *bean\n%.y\n\n&gt; `bean`&amp;\n%.y\n&gt; `bean`|\n%.n\n</code></pre>"
+  },
+  {
+    "keys": [
+      "beer"
+    ],
+    "doc": "<h1><code>++beer</code></h1>\n\n<p>Tape builder</p>\n\n<p>Used to build <a href=\"\">tape</a>s internally.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  beer  $|(@ [~ p=twig])                              ::  simple embed\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; `beer`'as'\n29.537\n&gt; `beer`[~ (ream 'lan')]\n[~ p=[%cnzz p=~[%lan]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "beet"
+    ],
+    "doc": "<h1><code>++beet</code></h1>\n\n<p>XML interpolation cases</p>\n\n<p>Used internally.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  beet  $|  @                                         ::  advanced embed\n          $%  [%a p=twig]                               ::  take tape\n              [%b p=twig]                               ::  take manx\n              [%c p=twig]                               ::  take marl\n              [%d p=twig]                               ::  take $+(marl marl)\n              [%e p=twig q=(list tuna)]                 ::  element literal\n          ==                                            ::\n</code></pre>"
+  },
+  {
+    "keys": [
+      "chum"
+    ],
+    "doc": "<h1><code>++chum</code></h1>\n\n<p>Jet hint information</p>\n\n<p>Jet hint information that must be present in the body of a <code>~/</code> or <code>~%</code>\nrune. A <code>++chum</code> can optionally contain a kelvin version, jet vendor,\nand \"{major}.{minor}\" version number.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  chum  $?  lef=term                                  ::  jet name\n              [std=term kel=@]                          ::  kelvin version\n              [ven=term pro=term kel=@]                 ::  vendor and product\n              [ven=term pro=term ver=@ kel=@]           ::  all of the above\n          ==                                            ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>XX there's a ++chum in zuse that's politely causing this not to work</p>\n\n<pre><code>&gt; `chum`'hi'\nlef=%hi\n\n&gt; (ream '~/(%lob.314 !!)')\n[%sgfs p=[std=%lob kel=314] q=[%zpzp ~]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "coil"
+    ],
+    "doc": "<h1><code>++coil</code></h1>\n\n<p>Tuple of core information</p>\n\n<p>Variance <code>p</code>, subject type <code>q</code>, and <code>q</code>: optional compiled nock, and arms. Used as an\nintermediate step within Section 2fB. Converted by <code>++core</code> to %core type.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  coil  $:  p=?(%gold %iron %lead %zinc)              ::  core type\n              q=type                                    ::\n              r=[p=?(~ ^) q=(map term foot)]            ::\n          ==                                            ::\n</code></pre>"
+  },
+  {
+    "keys": [
+      "foot"
+    ],
+    "doc": "<h1><code>++foot</code></h1>\n\n<p>Cases of arms by variance model.</p>\n\n<p><code>%ash</code> arms are <a href=\"\"><code>dry</code></a> and <a href=\"\">geometric</a>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  foot  $%  [%ash p=twig]                             ::  dry arm, geometric\n              [%elm p=twig]                             ::  wet arm, generic\n              [%oak ~]                                  ::  XX not used\n              [%yew p=(map term foot)]                  ::  XX not used\n          ==                                            ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>See also: <a href=\"\"><code>++ap</code></a>, <a href=\"\"><code>++ut</code></a></p>\n\n<pre><code> &gt; *foot\n[%yew p={}]\n\n&gt; (ream '|%  ++  $  foo  --')\n[%brcn p={[p=%$ q=[%ash p=[%cnzz p=~[%foo]]]]}]\n&gt; +&lt;+:(ream '|%  ++  $  foo  --')\nt=~[%ash %cnzz %foo]\n&gt; (foot +&lt;+:(ream '|%  ++  $  foo  --'))\n[%ash p=[%cnzz p=~[%foo]]]\n&gt; (foot +&lt;+:(ream '|%  +-  $  foo  --'))\n[%elm p=[%cnzz p=~[%foo]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "limb"
+    ],
+    "doc": "<h1><code>++limb</code></h1>\n\n<pre><code>++  limb  $|(term $%([%&amp; p=axis] [%| p=@ud q=term]))    ::\n</code></pre>\n\n<p>XX move to <code>++ut</code></p>\n\n<p>Reference into subject by name/axis</p>\n\n<p>See also: section 2fC-2fD</p>\n\n<pre><code>&gt; (ream '^^$')\n[%cnzz p=~[[%.n p=2 q=%$]]]\n&gt; (limb &amp;2:(ream '^^$'))\n[%.n p=2 q=%$]\n&gt; (limb &amp;2:(ream '^^^$'))\n[%.n p=3 q=%$]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "line"
+    ],
+    "doc": "<h1><code>++line</code></h1>\n\n<p>XX move to <code>++ut</code></p>\n\n<h2>Source</h2>\n\n<pre><code>++  line  ,[p=[%leaf p=odor q=@] q=tile]                ::  %kelp case\n</code></pre>\n\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (ream '$%([1 a] [%2 b])')\n[ %bccm\n    p\n  [ %kelp\n      p\n    [ i=[p=[%leaf p=~.ud q=1] q=[%herb p=[%cnzz p=~[%a]]]]\n      t=~[[p=[%leaf p=~.ud q=2] q=[%herb p=[%cnzz p=~[%b]]]]]\n    ]\n  ]\n]\n&gt; &amp;3:(ream '$%([1 a] [%2 b])')\np=[p=[%leaf p=%ud q=1] q=[%herb p=[%cnzz p=~[%a]]]]\n&gt; (line &amp;3:(ream '$%([1 a] [%2 b])'))\n[p=[%leaf p=~.ud q=1] q=[%herb p=[%cnzz p=~[%a]]]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "metl"
+    ],
+    "doc": "<h1><code>++metl</code></h1>\n\n<pre><code>++  metl  ?(%gold %iron %zinc %lead)                    ::  core variance\n</code></pre>\n\n<p>XX move to <code>++ut</code></p>\n\n<p>See also: <a href=\"\"><code>++coil</code></a></p>"
+  },
+  {
+    "keys": [
+      "nock"
+    ],
+    "doc": "<h1><code>++nock</code></h1>\n\n<p>Virtual machine. See <a href=\"\">Nock doc</a>.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>    ++  nock  $&amp;  [p=nock q=nock]                           ::  autocons\n              [%3 p=nock]                               ::  cell test\n              [%4 p=nock]                               ::  increment\n              [%5 p=nock q=nock]                        ::  equality test\n              [%6 p=nock q=nock r=nock]                 ::  if, then, else\n              [%7 p=nock q=nock]                        ::  serial compose\n              [%8 p=nock q=nock]                        ::  push onto subject\n              [%9 p=@ q=nock]                           ::  select arm and fire\n              [%10 p=?(@ [p=@ q=nock]) q=nock]          ::  hint\n              [%11 p=nock]                              ::  grab data from sky\n          ==                                            ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; !=([+(.) 20 -&lt;])\n[[4 0 1] [1 20] 0 4]\n&gt; (nock !=([+(.) 20]))\n[p=[%4 p=[%0 p=1]] q=[%1 p=20]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "noun"
+    ],
+    "doc": "<h1><code>++noun</code></h1>\n\n<pre><code>++  noun  ,*                                            ::  any noun\n</code></pre>\n\n<p>Used nowhere XX</p>\n\n<pre><code>&gt; `noun`~[1 2 3]\n[1 2 3 0]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "null"
+    ],
+    "doc": "<h1><code>++null</code></h1>\n\n<pre><code>++  null  ,~                                            ::  null, nil, etc\n</code></pre>\n\n<p>Used nowhere XX</p>\n\n<pre><code>&gt; :type; *null\n~\n%~\n</code></pre>"
+  },
+  {
+    "keys": [
+      "port"
+    ],
+    "doc": "<h1><code>++port</code></h1>\n\n<p>XX move to <code>++ut</code></p>\n\n<p>Type and location of core-shaped thing? XX Compiler Internals</p>\n\n<h2>Source</h2>\n\n<pre><code>++  port  $:  p=axis                                    ::\n              $=  q                                     ::\n              $%  [%&amp; p=type]                           ::\n                  [%| p=axis q=(list ,[p=type q=foot])] ::\n              ==                                        ::\n          ==                                            ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; *port\n[p=0 q=[%.y p=%void]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "span"
+    ],
+    "doc": "<h1><code>++span</code></h1>\n\n<p>ASCII atom</p>\n\n<p>A restricted text atom for canonical atom syntaxes. The prefix is <code>~.</code>.\nThere are no escape sequences except <code>~~</code>, which means <code>~</code>, and <code>~-</code>,\nwhich means <code>_</code>. <code>-</code> and <code>.</code> encode themselves. No other characters\nbesides numbers and lowercase letters are permitted.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  span  ,@ta                                          ::  text-atom (ASCII)\n</code></pre>\n<h2>Examples</h2>\n<pre><code>&gt; *span\n~.\n\n&gt; `@t`~.foo\n'foo'\n&gt; `@t`~.foo.bar\n'foo.bar'\n&gt; `@t`~.foo~~bar\n'foo~bar'\n&gt; `@t`~.foo~-bar\n'foo_bar'\n&gt; `@t`~.foo-bar\n'foo-bar'\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tiki"
+    ],
+    "doc": "<h1><code>++tiki</code></h1>\n\n<p>XX move to <code>++ut</code></p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  tiki                                                ::  test case\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>A <code>++wing</code> or <code>++twig</code>.</p>\n\n<pre><code>&gt; (ream '=+  a=4  ?-(a @ ~)')\n[ %tsls\n  p=[%ktts p=p=%a q=[%dtzy p=%ud q=4]]\n    q\n  [ %wthz\n    p=[%.y p=~ q=~[%a]] \n    q=~[[p=[%axil p=[%atom p=~.]] q=[%bczp p=%null]]]\n  ]\n]\n&gt; (ream '=+  a=4  ?-(4 @ ~)')\n[ %tsls\n  p=[%ktts p=p=%a q=[%dtzy p=%ud q=4]]\n    q\n  [ %wthz\n    p=[%.n p=~ q=[%dtzy p=%ud q=4]]\n    q=~[[p=[%axil p=[%atom p=~.]] q=[%bczp p=%null]]]\n  ]\n]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "toga"
+    ],
+    "doc": "<h1><code>++toga</code></h1>\n\n<p>Tree of faces</p>\n\n<p>A <a href=\"\">face</a>, or tree of faces. A <code>++toga</code> is applied to anything assigned\nusing <a href=\"\"><code>^=</code></a>.</p>\n\n<p>XX move to <code>++ut</code> and rune doc (for \\^= examples)</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  toga                                                ::  face control\n              [2 p=toga q=toga]                         ::  cell toga\n          ==                                            ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; a=1\na=1\n&gt; (ream 'a=1')\n[%ktts p=p=%a q=[%dtzy p=%ud q=1]]\n&gt; [a b]=[1 2 3]\n[a=1 b=[2 3]]\n&gt; (ream '[a b]=[1 2 3]')\n[ %ktts\n  p=[%2 p=p=%a q=p=%b]\n  q=[%cltr p=~[[%dtzy p=%ud q=1] [%dtzy p=%ud q=2] [%dtzy p=%ud q=3]]]\n]\n\n&gt; [a ~]=[1 2 3]\n[a=1 2 3]\n&gt; (ream '[a ~]=[1 2 3]')\n[ %ktts\n  p=[%2 p=p=%a q=[%0 ~]]\n  q=[%cltr p=~[[%dtzy p=%ud q=1] [%dtzy p=%ud q=2] [%dtzy p=%ud q=3]]]\n]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tone"
+    ],
+    "doc": "<h1><code>++tone</code></h1>\n\n<p>Intermediate Nock computation result</p>\n\n<p>Similar to <a href=\"\"><code>++toon</code></a>, but stack trace is not yet rendered.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  tone  $%  [%0 p=*]                                  ::  success\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (mink [[20 21] 0 3] ,~)\n[%0 p=21]\n\n&gt; (mink [[0] !=(.^(cy//=main/1))] ,~)\n[%1 p=~[[31.075 1.685.027.454 1.852.399.981 49 0]]]\n&gt; (path [31.075 1.685.027.454 1.852.399.981 49 0])\n/cy/~zod/main/1\n\n&gt; (mink [[1 2] !=(~|(%hi +(.)))] ,~)\n[%2 p=~[[~.yelp 26.984]]]\n&gt; (mink [[1 2] !=(!:(+(.)))] ,~)\n[ %2\n    p\n  ~[\n    [ ~.spot\n      [ [ 1.685.027.454\n          7.959.156\n          \\/159.445.990.350.374.058.574.398.238.344.143.957.205.628.479.572.65\\/\n            8.112.403.878.526\n          \\/                                                                  \\/\n          0\n        ]\n        [1 20]\n        1\n        24\n      ]\n    ]\n  ]\n]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "tuna"
+    ],
+    "doc": "<h1><code>++tuna</code></h1>\n\n<p>XML template tree</p>\n\n<p>An XML template tree.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  tuna                                                ::  tagflow\n              [%d p=twig]                               ::  dynamic list\n              [%e p=twig q=(list tuna)]                 ::  element\n              [%f p=(list tuna)]                        ::  subflow\n          ==                                            ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>Leaf %a contains plain-text, %b an empty tag, %c a static list, %d a\ndynamic list, %e a full node element containing a twig and a list of\ntuna, and %f is a empty node.</p>\n\n<p>See also: <a href=\"\"><code>++sail</code></a></p>"
+  },
+  {
+    "keys": [
+      "tusk"
+    ],
+    "doc": "<h1><code>++tusk</code></h1>\n\n<p>List of expressions</p>\n\n<p>List of <a href=\"\"><code>++twig</code></a>s. In <a href=\"\"><code>:*</code></a>, for example, your contents is\na <code>++tusk</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  tusk  (list twig)                                   ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (ream '[1 2 3]')\n[%cltr p=~[[%dtzy p=%ud q=1] [%dtzy p=%ud q=2] [%dtzy p=%ud q=3]]]\n&gt; (tusk +:(ream '[1 2 3]'))\n~[[%dtzy p=%ud q=1] [%dtzy p=%ud q=2] [%dtzy p=%ud q=3]]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "twig"
+    ],
+    "doc": "<h1><code>++twig</code></h1>\n\n<p>Expression</p>\n\n<p>An expression, or AST.</p>\n\n<p>See Twig section of Hoon reference</p>"
+  },
+  {
+    "keys": [
+      "tyke"
+    ],
+    "doc": "<h1><code>++tyke</code></h1>\n\n<p>List of 'maybe' twigs</p>\n\n<p>List of <a href=\"\"><code>++unit</code></a> <a href=\"\"><code>++twig</code></a>, or gaps left to be inferred, in <a href=\"\"><code>++path</code></a>\nparsing. When you use a path such as <code>/=main=/pub/src/doc</code> the path is in fact\na <code>++tyke</code>, where the <code>=</code> are inferred from your current path.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>    ++  tyke  (list (unit twig))                            ::\n</code></pre>\n\n<h2>Examples</h2>\n\n<pre><code>&gt; (scan \"/==as=\" porc:vast)\n[0 ~[~ ~ [~ [%dtzy p=%tas q=29.537]] ~]]\n&gt; `tyke`+:(scan \"/==as=\" porc:vast)\n~[~ ~ [~ [%dtzy p=%tas q=29.537]] ~]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "typo"
+    ],
+    "doc": "<h1><code>++typo</code></h1>\n\n<p>Pointer for <code>++type</code></p>\n\n<p>Pointer for <a href=\"\"><code>++type</code></a>. <code>++typo</code> preserves the previous <code>++type</code> in your\ncontext when upating.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  typo  type                                          ::  old type\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>See also: <code>++seem</code>, <code>++vise</code>, <code>++type</code></p>"
+  },
+  {
+    "keys": [
+      "tyre"
+    ],
+    "doc": "<h1><code>++tyre</code></h1>\n\n<p>List, term to twig</p>\n\n<p>Associative list of <a href=\"\">++term</a> <a href=\"\"><code>++twig</code></a>, used in <a href=\"\">jet</a> hint processing.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  tyre  (list ,[p=term q=twig])                       ::\n</code></pre>"
+  },
+  {
+    "keys": [
+      "vase"
+    ],
+    "doc": "<h1><code>++vase</code></h1>\n\n<p>Typed data. A <code>++vase</code> is used wherever typed data is explicitly worked\nwith.</p>\n\n\n<h2>Source</h2>\n\n<pre><code>    ++  vase  ,[p=type q=*]                                 ::  type-value pair\n</code></pre>\n\n<h2>Examples</h2>\n<p>See <code>%arvo</code> doc</p>\n\n<pre><code>&gt; `vase`!&gt;(~)\n[p=[%cube p=0 q=[%atom p=%n]] q=0]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "vise"
+    ],
+    "doc": "<h1><code>++vise</code></h1>\n\n<p>Convert during reboot</p>\n\n<p>Used to convert from previously-typed data during reboot.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  vise  ,[p=typo q=*]                                 ::  old vase\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>See also: <a href=\"\"><code>++typo</code></a>, <a href=\"\"><code>++seer</code></a></p>"
+  },
+
+  {
+    "keys": [
+      "mane"
+    ],
+    "doc": "<h1><code>++mane</code></h1>\n\n<p>XML name</p>\n\n<p>An XML name (tag name or attribute name) with an optional namespace.  Parsed by\n<code>++name</code> within <code>++poxa</code>, rendered by <code>++name</code> within <code>++poxo</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  mane  $@(@tas [@tas @tas])                          ::  XML name/space\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>See also: <code>++sail</code></p>\n\n<pre><code>&gt; *mane\n%$\n\n&gt; `mane`n.g:`manx`;div:namespace;\n%div\n&gt; `mane`n.g:`manx`;div_namespace;\n[%div %namespace]\n</code></pre>"
+  },
+  {
+    "keys": [
+      "manx"
+    ],
+    "doc": "<h1><code>++manx</code></h1>\n\n<p>XML node.</p>\n\n<p>Parsed by <code>++apex</code> within <code>++poxa</code>, rendered by <code>++poxo</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  manx  {g/marx c/marl}                              ::  XML node\n</code></pre>\n\n<h2>Examples</h2>\n\n<p>See also: <code>++sail</code> doc</p>"
+  },
+  {
+    "keys": [
+      "marl"
+    ],
+    "doc": "<h1><code>++marl</code></h1>\n\n<p>List of XML nodes</p>\n\n<p>A list of <a href=\"\"><code>++manx</code></a>.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  marl  (list manx)                                   ::  XML node list\n</code></pre>\n\n<h2>Examples</h2>"
+  },
+  {
+    "keys": [
+      "mars"
+    ],
+    "doc": "<h1><code>++mars</code></h1>\n\n<p>XML CDATA</p>\n\n<p>Implicitly produced by <code>++chrd</code> within <code>++poxa</code></p>\n\n<h2>Source</h2>\n\n<pre><code>++  mars  {t/{n/$$ a/{i/{n/$$ v/tape} t/$~}} c/$~}      ::  XML cdata\n</code></pre>\n\n\n<h2>Examples</h2>"
+  },
+  {
+    "keys": [
+      "mart"
+    ],
+    "doc": "<h1><code>++mart</code></h1>\n\n<p>List of XML attributes</p>\n\n<p>Each <code>++mart</code> is a list of pairs of <code>++mane</code> and\n<code>++tape</code>.</p>\n\n<p>Parsed by <code>++attr</code> within <code>++poxa</code>, rendered by <code>++attr</code> within <code>++poxo</code></p>\n\n<h2>Source</h2>\n\n<pre><code>++  mart  (list {n/mane v/tape})                       ::  XML attributes\n</code></pre>\n\n<h2>Examples</h2>"
+  },
+  {
+    "keys": [
+      "marx"
+    ],
+    "doc": "<h1><code>++marx</code></h1>\n\n<p>XML tag</p>\n\n<p>A <code>++marx</code> is a pair of a tag name, <code>++mane</code> and a list of attributes,\n<code>++mart</code>. Parsed by <code>++head</code> <code>++poxa</code>, rendered within <code>++poxo</code>.</p>\n\n<h2>Source</h2>\n\n<pre><code>++  marx  {n/mane a/mart}                              ::  XML tag\n</code></pre>\n\n<h2>Examples</h2>"
+  },
+  {
+    "keys": [
+      "pass"
+    ],
+    "doc": "<h1><code>++pass</code></h1>\n\n<p>Atom alias</p>\n\n<p>Used primarily in crypto.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  pass  @                                            ::  public key\n</code></pre>"
+  },
+  {
+    "keys": [
+      "ring"
+    ],
+    "doc": "<h1><code>++ring</code></h1>\n\n<p>Atom alias</p>\n\n<p>Used primarily in crypto.</p>\n\n<h2>Source</h2>\n\n<pre><code>    ++  ring  @                                            ::  private key\n</code></pre>"
   }
 ]


### PR DESCRIPTION
Wrote [a terrible Lua script](https://gist.github.com/Fang-/ad8bc5e82235cc23cb69deca318464ac) to scrape the online Urbit docs and output JSON, which I appended to the dictionary.

For functions like `+-all:in` I set their key to `all in` because that seems to be their most common form of use. Because of that space you're required to select the two words for the plugin to show you its documentation, rather than just place the cursor in/around them.

Functions from zuse aren't included, their documentation isn't nearly as uniform.